### PR TITLE
Add max cache size and garbage collection for the oci cache

### DIFF
--- a/ociclient/cache/cache_suite_test.go
+++ b/ociclient/cache/cache_suite_test.go
@@ -1,0 +1,415 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	testlog "github.com/go-logr/logr/testing"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/opencontainers/go-digest"
+	ocispecv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/gardener/component-cli/ociclient/metrics"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Cache Test Suite")
+}
+
+var _ = Describe("Cache", func() {
+
+	Context("Cache", func() {
+		It("should read data from the in memory cache", func() {
+			c, err := NewCache(testlog.NullLogger{}, WithInMemoryOverlay(true))
+			Expect(err).ToNot(HaveOccurred())
+			defer c.Close()
+
+			desc, data := exampleDataSet(10)
+			Expect(c.Add(desc, data)).To(Succeed())
+
+			r, err := c.Get(desc)
+			Expect(err).ToNot(HaveOccurred())
+			buf := readIntoBuffer(r)
+			Expect(buf.Len() > 0).To(BeTrue(), "The cache should return some data")
+			r, err = c.Get(desc)
+			Expect(err).ToNot(HaveOccurred())
+			buf = readIntoBuffer(r)
+			Expect(buf.Len() > 0).To(BeTrue(), "The cache should return some data")
+		})
+
+		Context("metrics", func() {
+			It("should read data from the in memory cache", func() {
+				dir, err := ioutil.TempDir(os.TempDir(), "test-")
+				Expect(err).ToNot(HaveOccurred())
+				defer func() {
+					Expect(os.RemoveAll(dir)).To(Succeed())
+				}()
+				metrics.CachedItems.Reset()
+				metrics.CacheHitsDisk.Reset()
+				metrics.CacheHitsMemory.Reset()
+				metrics.CacheDiskUsage.Reset()
+				metrics.CacheMemoryUsage.Reset()
+
+				c, err := NewCache(testlog.NullLogger{}, WithBasePath(dir), WithInMemoryOverlay(true))
+				Expect(err).ToNot(HaveOccurred())
+				defer c.Close()
+
+				desc, data := exampleDataSet(10)
+				Expect(c.Add(desc, data)).To(Succeed())
+
+				expected := `
+				# HELP ociclient_cache_items_total Total number of items currently cached by instance.
+                # TYPE ociclient_cache_items_total gauge
+                ociclient_cache_items_total{path="%s"} 1
+				`
+				Expect(testutil.CollectAndCompare(metrics.CachedItems, strings.NewReader(fmt.Sprintf(expected, dir)))).To(Succeed())
+				expected = `
+				# HELP ociclient_cache_disk_hits_total Total number of hits for items cached on disk by an instance.
+                # TYPE ociclient_cache_disk_hits_total counter
+                ociclient_cache_disk_hits_total{path="%s"} 0
+				`
+				Expect(testutil.CollectAndCompare(metrics.CacheHitsDisk, strings.NewReader(fmt.Sprintf(expected, dir)))).To(Succeed())
+				expected = `
+				# HELP ociclient_cache_memory_hits_total Total number of hits for items cached in memory by an instance.
+                # TYPE ociclient_cache_memory_hits_total counter
+                ociclient_cache_memory_hits_total{path="%s"} 0
+				`
+				Expect(testutil.CollectAndCompare(metrics.CacheHitsMemory, strings.NewReader(fmt.Sprintf(expected, dir)))).To(Succeed())
+				expected = `
+				# HELP ociclient_cache_memory_usage_bytes Bytes in memory currently used by cache instance.
+                # TYPE ociclient_cache_memory_usage_bytes gauge
+                ociclient_cache_memory_usage_bytes{path="%s"} 0
+				`
+				Expect(testutil.CollectAndCompare(metrics.CacheMemoryUsage, strings.NewReader(fmt.Sprintf(expected, dir)))).To(Succeed())
+
+				r, err := c.Get(desc)
+				Expect(err).ToNot(HaveOccurred())
+				buf := readIntoBuffer(r)
+				Expect(buf.Len() > 0).To(BeTrue(), "The cache should return some data")
+				r, err = c.Get(desc)
+				Expect(err).ToNot(HaveOccurred())
+				buf = readIntoBuffer(r)
+				Expect(buf.Len() > 0).To(BeTrue(), "The cache should return some data")
+
+				expected = `
+				# HELP ociclient_cache_items_total Total number of items currently cached by instance.
+                # TYPE ociclient_cache_items_total gauge
+                ociclient_cache_items_total{path="%s"} 1
+				`
+				Expect(testutil.CollectAndCompare(metrics.CachedItems, strings.NewReader(fmt.Sprintf(expected, dir)))).To(Succeed())
+				expected = `
+				# HELP ociclient_cache_disk_usage_bytes Bytes on disk currently used by cache instance.
+                # TYPE ociclient_cache_disk_usage_bytes gauge
+                ociclient_cache_disk_usage_bytes{path="%s"} 10
+				`
+				Expect(testutil.CollectAndCompare(metrics.CacheDiskUsage, strings.NewReader(fmt.Sprintf(expected, dir)))).To(Succeed())
+				expected = `
+				# HELP ociclient_cache_disk_hits_total Total number of hits for items cached on disk by an instance.
+                # TYPE ociclient_cache_disk_hits_total counter
+                ociclient_cache_disk_hits_total{path="%s"} 1
+				`
+				Expect(testutil.CollectAndCompare(metrics.CacheHitsDisk, strings.NewReader(fmt.Sprintf(expected, dir)))).To(Succeed())
+				expected = `
+				# HELP ociclient_cache_memory_hits_total Total number of hits for items cached in memory by an instance.
+                # TYPE ociclient_cache_memory_hits_total counter
+                ociclient_cache_memory_hits_total{path="%s"} 1
+				`
+				Expect(testutil.CollectAndCompare(metrics.CacheHitsMemory, strings.NewReader(fmt.Sprintf(expected, dir)))).To(Succeed())
+				expected = `
+				# HELP ociclient_cache_memory_usage_bytes Bytes in memory currently used by cache instance.
+                # TYPE ociclient_cache_memory_usage_bytes gauge
+                ociclient_cache_memory_usage_bytes{path="%s"} 10
+				`
+				Expect(testutil.CollectAndCompare(metrics.CacheMemoryUsage, strings.NewReader(fmt.Sprintf(expected, dir)))).To(Succeed())
+			})
+		})
+	})
+
+	Context("GC", func() {
+		It("should garbage collect when the cache reaches its max size", func() {
+			c, err := NewCache(testlog.NullLogger{}, WithBaseSize("1Ki"))
+			Expect(err).ToNot(HaveOccurred())
+			defer c.Close()
+
+			Expect(c.Add(exampleDataSet(500))).To(Succeed())
+			Expect(c.baseFs.index.entries).To(HaveLen(1))
+			Expect(c.Add(exampleDataSet(500))).To(Succeed())
+			Eventually(func() map[string]IndexEntry {
+				return c.baseFs.index.entries
+			}).Should(HaveLen(1))
+		})
+
+		It("should garbage collect the in memory cache but not the base cache if the size exceeds", func() {
+			c, err := NewCache(testlog.NullLogger{}, WithInMemoryOverlay(true), WithInMemoryOverlaySize("1Ki"))
+			Expect(err).ToNot(HaveOccurred())
+			defer c.Close()
+
+			desc1, buf := exampleDataSet(500)
+			Expect(c.Add(desc1, buf)).To(Succeed())
+			desc2, buf := exampleDataSet(500)
+			Expect(c.Add(desc2, buf)).To(Succeed())
+			// let both files be added to the in memory cache by reading them
+			r, err := c.Get(desc1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r.Close()).To(Succeed())
+			r, err = c.Get(desc2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r.Close()).To(Succeed())
+
+			Eventually(func() map[string]IndexEntry {
+				return c.baseFs.index.entries
+			}).Should(HaveLen(2))
+			Eventually(func() map[string]IndexEntry {
+				return c.overlayFs.index.entries
+			}).Should(HaveLen(1))
+		})
+
+		It("should delete files until the low threshold has been reached", func() {
+			c, err := NewCache(testlog.NullLogger{}, WithBaseSize("1Ki"))
+			Expect(err).ToNot(HaveOccurred())
+			defer c.Close()
+
+			desc1, buf := exampleDataSet(500)
+			Expect(c.Add(desc1, buf)).To(Succeed())
+			r, err := c.Get(desc1)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r.Close()).To(Succeed())
+
+			for i := 0; i < 100; i++ {
+				Expect(c.Add(exampleDataSet(100 + i))).To(Succeed())
+			}
+
+			Eventually(c.baseFs.CurrentSize).Should(BeNumerically("<", 1024))
+		})
+	})
+
+	Context("Index", func() {
+
+		It("should add 2 entries to the index", func() {
+			index := NewIndex()
+			index.Add("a", 500, time.Now())
+			index.Add("b", 500, time.Now())
+
+			list := index.PriorityList()
+			Expect(list).To(HaveLen(2))
+		})
+
+		It("should return a prioritised entries based on hits", func() {
+			index := NewIndex()
+			index.Add("a", 500, newDate("0:01AM"))
+			index.Add("b", 500, newDate("0:01AM"))
+			index.Hit("a")
+			list := index.PriorityList()
+			Expect(list).To(HaveLen(2))
+
+			Expect(list[0].Name).To(Equal("b"))
+			Expect(list[1].Name).To(Equal("a"))
+
+			index = NewIndex()
+			index.Add("a", 500, newDate("0:01AM"))
+			index.Add("b", 500, newDate("0:01AM"))
+			index.Hit("b")
+			list = index.PriorityList()
+			Expect(list).To(HaveLen(2))
+
+			Expect(list[0].Name).To(Equal("a"))
+			Expect(list[1].Name).To(Equal("b"))
+		})
+
+		It("should return a prioritised entries based on added date", func() {
+			index := NewIndex()
+			index.Add("b", 500, newDate("0:01AM"))
+			index.Add("a", 500, newDate("0:03AM"))
+			list := index.PriorityList()
+			Expect(list).To(HaveLen(2))
+
+			Expect(list[0].Name).To(Equal("b"))
+			Expect(list[1].Name).To(Equal("a"))
+
+			index = NewIndex()
+			index.Add("a", 500, newDate("0:01AM"))
+			index.Add("b", 500, newDate("0:03AM"))
+			list = index.PriorityList()
+			Expect(list).To(HaveLen(2))
+
+			Expect(list[0].Name).To(Equal("a"))
+			Expect(list[1].Name).To(Equal("b"))
+		})
+
+		It("should return a prioritised entries based on hits and added date", func() {
+			index := NewIndex()
+			index.Add("a", 500, newDate("0:01AM"))
+			index.Add("b", 500, newDate("0:02AM"))
+			index.Add("c", 500, newDate("0:03AM"))
+			index.Add("d", 500, newDate("0:04AM"))
+			index.Hit("b")
+			index.Hit("c")
+			index.Hit("c")
+			list := index.PriorityList()
+			Expect(list).To(HaveLen(4))
+
+			Expect(list[0].Name).To(Equal("a"))
+			Expect(list[1].Name).To(Equal("d"))
+			Expect(list[2].Name).To(Equal("b"))
+			Expect(list[3].Name).To(Equal("c"))
+		})
+
+		Context("Hits", func() {
+			It("should add hits to a entry", func() {
+				index := NewIndex()
+				index.Add("a", 500, newDate("0:01AM"))
+				index.Hit("a")
+				list := index.PriorityList()
+				Expect(list).To(HaveLen(1))
+				Expect(list[0].Hits).To(Equal(int64(1)))
+
+				index.Hit("a")
+				list = index.PriorityList()
+				Expect(list).To(HaveLen(1))
+				Expect(list[0].Hits).To(Equal(int64(2)))
+			})
+
+			It("should reset hits and keep 100% of newly added hits", func() {
+				index := NewIndex()
+				index.Add("a", 500, newDate("0:01AM"))
+
+				index.Hit("a")
+				index.Hit("a")
+				index.Hit("a")
+				index.Hit("a")
+				index.Reset()
+				list := index.PriorityList()
+				Expect(list).To(HaveLen(1))
+				Expect(list[0].Hits).To(Equal(int64(4)))
+			})
+
+			It("should reset hits and keep 100% of newly added hits and preserve 50% of old hits", func() {
+				index := NewIndex()
+				index.Add("a", 500, newDate("0:01AM"))
+
+				index.Hit("a")
+				index.Hit("a")
+				index.Reset()
+				index.Hit("a")
+				index.Hit("a")
+				index.Reset()
+				list := index.PriorityList()
+				Expect(list).To(HaveLen(1))
+				Expect(list[0].Hits).To(Equal(int64(3)))
+			})
+		})
+
+		Context("CalculatePriority", func() {
+			It("should prioritise more hits if added at the same time", func() {
+				var minHits, maxHits int64 = 2, 6
+				oldest := newDate("0:01AM")
+				newest := newDate("11:59AM")
+
+				entryA := IndexEntry{
+					Hits:      3,
+					CreatedAt: newDate("0:04AM"),
+				}
+				valA := CalculatePriority(entryA, minHits, maxHits, oldest, newest)
+
+				entryB := IndexEntry{
+					Hits:      4,
+					CreatedAt: newDate("0:04AM"),
+				}
+				valB := CalculatePriority(entryB, minHits, maxHits, oldest, newest)
+
+				Expect(valA).To(BeNumerically("<", valB))
+			})
+
+			It("should prioritise the creation date if the hits are the same", func() {
+				var minHits, maxHits int64 = 2, 6
+				oldest := newDate("0:01AM")
+				newest := newDate("11:59AM")
+
+				entryA := IndexEntry{
+					Hits:      4,
+					CreatedAt: newDate("0:04AM"),
+				}
+				valA := CalculatePriority(entryA, minHits, maxHits, oldest, newest)
+
+				entryB := IndexEntry{
+					Hits:      4,
+					CreatedAt: newDate("0:03AM"),
+				}
+				valB := CalculatePriority(entryB, minHits, maxHits, oldest, newest)
+
+				Expect(valA).To(BeNumerically(">", valB))
+			})
+
+			It("should prioritise the hits over the creation date", func() {
+				var minHits, maxHits int64 = 2, 6
+				oldest := newDate("0:01AM")
+				newest := newDate("11:59AM")
+
+				entryA := IndexEntry{
+					Hits:      3,
+					CreatedAt: newDate("0:04AM"),
+				}
+				valA := CalculatePriority(entryA, minHits, maxHits, oldest, newest)
+
+				entryB := IndexEntry{
+					Hits:      4,
+					CreatedAt: newDate("0:03AM"),
+				}
+				valB := CalculatePriority(entryB, minHits, maxHits, oldest, newest)
+
+				Expect(valA).To(BeNumerically("<", valB))
+			})
+		})
+
+	})
+
+})
+
+func readIntoBuffer(r io.ReadCloser) *bytes.Buffer {
+	var data bytes.Buffer
+	_, err := io.Copy(&data, r)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(r.Close()).To(Succeed())
+	return &data
+}
+
+func exampleDataSet(size int) (ocispecv1.Descriptor, io.ReadCloser) {
+	buf := exampleData(size)
+	desc := exampleDesc(buf)
+	return desc, ioutil.NopCloser(buf)
+}
+
+func exampleDesc(buf *bytes.Buffer) ocispecv1.Descriptor {
+	return ocispecv1.Descriptor{
+		MediaType: "application/octet-stream",
+		Size:      int64(buf.Len()),
+		Digest:    digest.FromBytes(buf.Bytes()),
+	}
+}
+
+func exampleData(size int) *bytes.Buffer {
+	data := make([]byte, size)
+	_, err := rand.Read(data)
+	Expect(err).ToNot(HaveOccurred())
+	return bytes.NewBuffer(data)
+}
+
+func newDate(val string) time.Time {
+	t, err := time.Parse(time.Kitchen, val)
+	Expect(err).ToNot(HaveOccurred())
+	return t
+}

--- a/ociclient/cache/filesystem.go
+++ b/ociclient/cache/filesystem.go
@@ -1,0 +1,463 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/mandelsoft/vfs/pkg/vfs"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// GCHighThreshold defines the default percent of disk usage which triggers files garbage collection.
+const GCHighThreshold float64 = 0.85
+
+// GCLowThreshold defines the default percent of disk usage to which files garbage collection attempts to free.
+const GCLowThreshold float64 = 0.80
+
+// ResetInterval defines the default interval when the hit reset should run.
+const ResetInterval time.Duration = 1 * time.Hour
+
+// PreservedHitsProportion defines the default percent of hits that should be preserved.
+const PreservedHitsProportion = 0.5
+
+// GarbageCollectionConfiguration contains all options for the cache garbage collection.
+type GarbageCollectionConfiguration struct {
+	// Size is the size of the filesystem.
+	// If the value is 0 there is no limit and no garbage collection will happen.
+	// See the kubernetes quantity docs for detailed description of the format
+	// https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go
+	Size string
+	// GCHighThreshold defines the percent of disk usage which triggers files garbage collection.
+	GCHighThreshold float64
+	// GCLowThreshold defines the percent of disk usage to which files garbage collection attempts to free.
+	GCLowThreshold float64
+	// ResetInterval defines the interval when the hit reset should run.
+	ResetInterval time.Duration
+	// PreservedHitsProportion defines the percent of hits that should be preserved.
+	PreservedHitsProportion float64
+}
+
+// FileSystem is a internal representation of FileSystem with a optional max size
+// and a garbage collection.
+type FileSystem struct {
+	log logr.Logger
+	mux sync.Mutex
+
+	// Configuration
+	vfs.FileSystem
+	// Size is the size of the filesystem in bytes.
+	// If the value is 0 there is no limit and no garbage collection will happen.
+	Size int64
+	// GCHighThreshold defines the percent of disk usage which triggers files garbage collection.
+	GCHighThreshold float64
+	// GCLowThreshold defines the percent of disk usage to which files garbage collection attempts to free.
+	GCLowThreshold float64
+	// ResetInterval defines the interval when the hit reset should run.
+	ResetInterval time.Duration
+	// PreservedHitsProportion defines the percent of hits that should be preserved.
+	PreservedHitsProportion float64
+
+	index Index
+	// currentSize is the current size of the filesystem.
+	currentSize   int64
+	resetStopChan chan struct{}
+
+	// optional metrics
+	itemsCountMetric prometheus.Gauge
+	diskUsageMetric  prometheus.Gauge
+	hitsCountMetric  prometheus.Counter
+}
+
+// ApplyOptions parses and applies the options to the filesystem.
+// It also applies defaults
+func (o GarbageCollectionConfiguration) ApplyOptions(fs *FileSystem) error {
+	if len(o.Size) == 0 {
+		// no garbage collection configured ignore all other values
+		return nil
+	}
+	quantity, err := resource.ParseQuantity(o.Size)
+	if err != nil {
+		return fmt.Errorf("unable to parse size %q: %w", o.Size, err)
+	}
+	sizeInBytes, ok := quantity.AsInt64()
+	if ok {
+		fs.Size = sizeInBytes
+	}
+
+	if o.GCHighThreshold == 0 {
+		o.GCHighThreshold = GCHighThreshold
+	}
+	fs.GCHighThreshold = o.GCHighThreshold
+
+	if o.GCLowThreshold == 0 {
+		o.GCLowThreshold = GCLowThreshold
+	}
+	fs.GCLowThreshold = o.GCLowThreshold
+
+	if o.ResetInterval == 0 {
+		o.ResetInterval = ResetInterval
+	}
+	fs.ResetInterval = o.ResetInterval
+
+	if o.PreservedHitsProportion == 0 {
+		o.PreservedHitsProportion = PreservedHitsProportion
+	}
+	fs.PreservedHitsProportion = o.PreservedHitsProportion
+
+	return nil
+}
+
+// Merge merges 2 gc configurations whereas the defined values are overwritten.
+func (o GarbageCollectionConfiguration) Merge(cfg *GarbageCollectionConfiguration) {
+	if len(o.Size) != 0 {
+		cfg.Size = o.Size
+	}
+	if o.GCHighThreshold != 0 {
+		cfg.GCHighThreshold = o.GCHighThreshold
+	}
+	if o.GCLowThreshold != 0 {
+		cfg.GCLowThreshold = o.GCLowThreshold
+	}
+	if o.ResetInterval != 0 {
+		cfg.ResetInterval = o.ResetInterval
+	}
+	if o.PreservedHitsProportion != 0 {
+		cfg.PreservedHitsProportion = o.PreservedHitsProportion
+	}
+}
+
+// NewCacheFilesystem creates a new FileSystem cache.
+// It acts as a replacement for a vfs filesystem that restricts the size of the filesystem.
+// The garbage collection is triggered when a file is created.
+// When the filesystem is not used anymore fs.Close() should be called to gracefully free resources.
+func NewCacheFilesystem(log logr.Logger, fs vfs.FileSystem, gcOpts GarbageCollectionConfiguration) (*FileSystem, error) {
+	cFs := &FileSystem{
+		log:        log,
+		FileSystem: fs,
+		index:      NewIndex(),
+	}
+	if err := gcOpts.ApplyOptions(cFs); err != nil {
+		return nil, err
+	}
+
+	// load all cached files from the filesystem
+	files, err := vfs.ReadDir(fs, "/")
+	if err != nil {
+		return nil, fmt.Errorf("unable to read current cached files: %w", err)
+	}
+	for _, file := range files {
+		cFs.currentSize = cFs.currentSize + file.Size()
+		cFs.index.Add(file.Name(), file.Size(), file.ModTime())
+	}
+
+	if cFs.Size != 0 {
+		// start hit reset counter
+		cFs.StartResetInterval()
+	}
+
+	return cFs, nil
+}
+
+// WithMetrics adds prometheus metrics to the filesystem
+// that are set by the filesystem.
+func (fs *FileSystem) WithMetrics(itemsCount, usage prometheus.Gauge, hits prometheus.Counter) {
+	fs.diskUsageMetric = usage
+	fs.hitsCountMetric = hits
+	fs.itemsCountMetric = itemsCount
+
+	if fs.diskUsageMetric != nil {
+		fs.diskUsageMetric.Set(float64(fs.CurrentSize()))
+	}
+	if fs.itemsCountMetric != nil {
+		fs.itemsCountMetric.Set(float64(fs.index.Len()))
+	}
+}
+
+// Close implements the io.Closer interface.
+// It should be called when the cache is not used anymore.
+func (fs *FileSystem) Close() error {
+	if fs.resetStopChan == nil {
+		return nil
+	}
+	fs.resetStopChan <- struct{}{}
+	return nil
+}
+
+var _ io.Closer = &FileSystem{}
+
+// StartResetInterval starts the reset counter for the cache hits.
+func (fs *FileSystem) StartResetInterval() {
+	interval := time.NewTicker(ResetInterval)
+	fs.resetStopChan = make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-interval.C:
+				fs.index.Reset()
+			case <-fs.resetStopChan:
+				interval.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func (fs *FileSystem) Create(path string, size int64) (vfs.File, error) {
+	fs.mux.Lock()
+	defer fs.mux.Unlock()
+	file, err := fs.FileSystem.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	fs.setCurrentSize(fs.currentSize + size)
+	fs.index.Add(path, size, time.Now())
+	if fs.itemsCountMetric != nil {
+		fs.itemsCountMetric.Inc()
+	}
+	go fs.RunGarbageCollection()
+	return file, err
+}
+
+func (fs *FileSystem) OpenFile(name string, flags int, perm os.FileMode) (vfs.File, error) {
+	fs.index.Hit(name)
+	if fs.hitsCountMetric != nil {
+		fs.hitsCountMetric.Inc()
+	}
+	return fs.FileSystem.OpenFile(name, flags, perm)
+}
+
+func (fs *FileSystem) Remove(name string) error {
+	if err := fs.FileSystem.Remove(name); err != nil {
+		return err
+	}
+	entry := fs.index.Get(name)
+	fs.setCurrentSize(fs.currentSize - entry.Size)
+	fs.index.Remove(name)
+	if fs.itemsCountMetric != nil {
+		fs.itemsCountMetric.Dec()
+	}
+	return nil
+}
+
+// CurrentSize returns the current size of the filesystem
+func (fs *FileSystem) CurrentSize() int64 {
+	return fs.currentSize
+}
+
+// setCurrentSize sets the current size of the filesystem
+func (fs *FileSystem) setCurrentSize(size int64) {
+	fs.currentSize = size
+	if fs.diskUsageMetric != nil {
+		fs.diskUsageMetric.Set(float64(size))
+	}
+}
+
+// usage returns the current disk usage of the filesystem
+func (fs *FileSystem) usage() float64 {
+	return float64(fs.currentSize) / float64(fs.Size)
+}
+
+// RunGarbageCollection runs the garbage collection of the filesystem.
+// The gc only deletes items when the max size reached a certain threshold.
+// If that threshold is reached the files are deleted with the following priority:
+// - least hits
+// - oldest
+// - random
+func (fs *FileSystem) RunGarbageCollection() {
+	// do not run gc if the size is infinite
+	if fs.Size == 0 {
+		return
+	}
+	// first check if we reached the threshold to start garbage collection
+	if usage := fs.usage(); usage < GCHighThreshold {
+		fs.log.V(10).Info(fmt.Sprintf("run gc with %v%% usage", usage))
+		return
+	}
+
+	// while the index is read and copied no write should happen
+	fs.mux.Lock()
+	index := fs.index.DeepCopy()
+	fs.mux.Unlock()
+
+	// while the garbage collection is running read operations are blocked
+	// todo: improve to only block read operations on really deleted objects
+	fs.mux.Lock()
+	defer fs.mux.Unlock()
+
+	// sort all files according to their deletion priority
+	items := index.PriorityList()
+	for fs.usage() > GCLowThreshold {
+		if len(items) == 0 {
+			return
+		}
+		item := items[0]
+		if err := fs.Remove(item.Name); err != nil {
+			fs.log.Error(err, "unable to delete file", "file", item.Name)
+		}
+		// remove currently garbage collected item
+		items = items[1:]
+	}
+}
+
+type Index struct {
+	entries map[string]IndexEntry
+}
+
+// NewIndex creates a new index structure
+func NewIndex() Index {
+	return Index{entries: map[string]IndexEntry{}}
+}
+
+type IndexEntry struct {
+	// Name is the name if the file.
+	Name string
+	// Size is the size of the file in bytes.
+	Size int64
+	// Is the number of hits since the last gc
+	Hits int64
+	// CreatedAt is the time when the file ha been created.
+	CreatedAt time.Time
+	// HitsSinceLastReset is the number hits since the last reset interval
+	HitsSinceLastReset int64
+}
+
+// Add adds a entry to the index.
+func (i Index) Add(name string, size int64, createdAt time.Time) {
+	i.entries[name] = IndexEntry{
+		Name:               name,
+		Size:               size,
+		Hits:               0,
+		CreatedAt:          createdAt,
+		HitsSinceLastReset: 0,
+	}
+}
+
+// Len returns the number of items that are currently in the index.
+func (i Index) Len() int {
+	return len(i.entries)
+}
+
+// Get return the index entry with the given name.
+func (i Index) Get(name string) IndexEntry {
+	return i.entries[name]
+}
+
+// Remove removes the entry from the index.
+func (i Index) Remove(name string) {
+	delete(i.entries, name)
+}
+
+// Hit increases the hit count for the file.
+func (i Index) Hit(name string) {
+	entry, ok := i.entries[name]
+	if !ok {
+		return
+	}
+	entry.Hits++
+	entry.HitsSinceLastReset++
+	i.entries[name] = entry
+}
+
+// Reset resets the hit counter for all entries.
+// The reset preserves 20% if the old hits.
+func (i Index) Reset() {
+	for name := range i.entries {
+		entry := i.Get(name)
+
+		oldHits := entry.Hits - entry.HitsSinceLastReset
+		preservedHits := int64(float64(oldHits) * PreservedHitsProportion)
+		entry.Hits = preservedHits + entry.HitsSinceLastReset
+
+		entry.HitsSinceLastReset = 0
+		i.entries[name] = entry
+	}
+}
+
+// DeepCopy creates a deep copy of the current index.
+func (i Index) DeepCopy() Index {
+	index := Index{
+		entries: make(map[string]IndexEntry, len(i.entries)),
+	}
+	for key, value := range i.entries {
+		index.entries[key] = value
+	}
+	return index
+}
+
+// PriorityList returns a entries of all entries
+// sorted by their gc priority.
+// The entry with the lowest priority is the first item.
+func (i Index) PriorityList() []IndexEntry {
+	p := priorityList{
+		entries: make([]IndexEntry, 0),
+	}
+	for _, i := range i.entries {
+		entry := i
+		if entry.Hits > p.maxHits {
+			p.maxHits = entry.Hits
+		}
+		if p.minHits == 0 || entry.Hits < p.minHits {
+			p.minHits = entry.Hits
+		}
+		if p.newest.Before(entry.CreatedAt) {
+			p.newest = entry.CreatedAt
+		}
+		if p.oldest.IsZero() || entry.CreatedAt.Before(p.oldest) {
+			p.oldest = entry.CreatedAt
+		}
+		p.entries = append(p.entries, entry)
+	}
+	sort.Sort(p)
+	return p.entries
+}
+
+// priorityList is a helper type that implements the sort.Sort function.
+// the entries are sorted by their priority.
+// The priority is calculated using the entries hits and creation date.
+type priorityList struct {
+	minHits, maxHits int64
+	oldest, newest   time.Time
+	entries          []IndexEntry
+}
+
+var _ sort.Interface = priorityList{}
+
+func (i priorityList) Len() int { return len(i.entries) }
+
+func (i priorityList) Less(a, b int) bool {
+	eA, eB := i.entries[a], i.entries[b]
+
+	// calculate the entries hits value
+	// based on the min and max values
+	priorityA := CalculatePriority(eA, i.minHits, i.maxHits, i.oldest, i.newest)
+	priorityB := CalculatePriority(eB, i.minHits, i.maxHits, i.oldest, i.newest)
+	return priorityA < priorityB
+}
+
+// CalculatePriority calculates the gc priority of a index entry.
+// A lower priority means that is more likely to be deleted.
+func CalculatePriority(entry IndexEntry, minHits, maxHits int64, oldest, newest time.Time) float64 {
+	hitsVal := float64(entry.Hits-minHits) / float64(maxHits-minHits)
+	if math.IsNaN(hitsVal) {
+		hitsVal = 0
+	}
+	dateVal := float64(entry.CreatedAt.Unix()-oldest.Unix()) / float64(newest.Unix()-oldest.Unix())
+	if math.IsNaN(dateVal) {
+		dateVal = 0
+	}
+
+	return (hitsVal * 0.6) + (dateVal * 0.4)
+}
+
+func (i priorityList) Swap(a, b int) { i.entries[a], i.entries[b] = i.entries[b], i.entries[a] }

--- a/ociclient/cache/types.go
+++ b/ociclient/cache/types.go
@@ -21,6 +21,7 @@ const CacheDirEnvName = "OCI_CACHE_DIR"
 
 // Cache is the interface for a oci cache
 type Cache interface {
+	io.Closer
 	Get(desc ocispecv1.Descriptor) (io.ReadCloser, error)
 	Add(desc ocispecv1.Descriptor, reader io.ReadCloser) error
 }
@@ -46,15 +47,15 @@ type Options struct {
 	// InMemoryOverlay specifies if a overlayFs InMemory cache should be used
 	InMemoryOverlay bool
 
-	// OverlaySizeMB is the size of the overlay cache in MB
-	OverlaySizeMB int64
+	// InMemoryGCConfig defines the garbage collection configuration for the in memory cache.
+	InMemoryGCConfig GarbageCollectionConfiguration
 
 	// BasePath specifies the Base path for the os filepath.
 	// Will be defaulted to a temp filepath if not specified
 	BasePath string
 
-	// BaseSizeGB is the max size of the base cache in GB
-	BaseSizeGB int64
+	// BaseGCConfig defines the garbage collection configuration for the in base cache.
+	BaseGCConfig GarbageCollectionConfiguration
 }
 
 // Option is the interface to specify different cache options
@@ -62,13 +63,20 @@ type Option interface {
 	ApplyOption(options *Options)
 }
 
-// ApplyOptions applies the given list options on these options,
+// ApplyOptions applies the given entries options on these options,
 // and then returns itself (for convenient chaining).
 func (o *Options) ApplyOptions(opts []Option) *Options {
 	for _, opt := range opts {
 		opt.ApplyOption(o)
 	}
 	return o
+}
+
+// ApplyDefaults sets defaults for the options.
+func (o *Options) ApplyDefaults() {
+	if o.InMemoryOverlay && len(o.InMemoryGCConfig.Size) == 0 {
+		o.InMemoryGCConfig.Size = "200Mi"
+	}
 }
 
 // WithInMemoryOverlay is the options to specify the usage of a in memory overlayFs
@@ -85,16 +93,45 @@ func (p WithBasePath) ApplyOption(options *Options) {
 	options.BasePath = string(p)
 }
 
-// WithOverlaySize sets the max size of the overly file system in MB
-type WithOverlaySize int64
+// WithInMemoryOverlaySize sets the max size of the overly file system.
+// See the kubernetes quantity docs for detailed description of the format
+// https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go
+type WithInMemoryOverlaySize string
 
-func (p WithOverlaySize) ApplyOption(options *Options) {
-	options.OverlaySizeMB = int64(p)
+func (p WithInMemoryOverlaySize) ApplyOption(options *Options) {
+	options.InMemoryGCConfig.Size = string(p)
 }
 
-// WithBaseSize sets the max size of the base file system in GB
-type WithBaseSize int64
+// WithBaseSize sets the max size of the base file system.
+// See the kubernetes quantity docs for detailed description of the format
+// https://github.com/kubernetes/apimachinery/blob/master/pkg/api/resource/quantity.go
+type WithBaseSize string
 
 func (p WithBaseSize) ApplyOption(options *Options) {
-	options.BaseSizeGB = int64(p)
+	options.BaseGCConfig.Size = string(p)
+}
+
+// WithGCConfig overwrites the garbage collection settings for all caches.
+type WithGCConfig GarbageCollectionConfiguration
+
+func (p WithGCConfig) ApplyOption(options *Options) {
+	cfg := GarbageCollectionConfiguration(p)
+	cfg.Merge(&options.BaseGCConfig)
+	cfg.Merge(&options.InMemoryGCConfig)
+}
+
+// WithBaseGCConfig overwrites the base garbage collection settings.
+type WithBaseGCConfig GarbageCollectionConfiguration
+
+func (p WithBaseGCConfig) ApplyOption(options *Options) {
+	cfg := GarbageCollectionConfiguration(p)
+	cfg.Merge(&options.BaseGCConfig)
+}
+
+// WithBaseGCConfig overwrites the in memory garbage collection settings.
+type WithInMemoryGCConfig GarbageCollectionConfiguration
+
+func (p WithInMemoryGCConfig) ApplyOption(options *Options) {
+	cfg := GarbageCollectionConfiguration(p)
+	cfg.Merge(&options.InMemoryGCConfig)
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
@@ -1,0 +1,187 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides helpers to test code using the prometheus package
+// of client_golang.
+//
+// While writing unit tests to verify correct instrumentation of your code, it's
+// a common mistake to mostly test the instrumentation library instead of your
+// own code. Rather than verifying that a prometheus.Counter's value has changed
+// as expected or that it shows up in the exposition after registration, it is
+// in general more robust and more faithful to the concept of unit tests to use
+// mock implementations of the prometheus.Counter and prometheus.Registerer
+// interfaces that simply assert that the Add or Register methods have been
+// called with the expected arguments. However, this might be overkill in simple
+// scenarios. The ToFloat64 function is provided for simple inspection of a
+// single-value metric, but it has to be used with caution.
+//
+// End-to-end tests to verify all or larger parts of the metrics exposition can
+// be implemented with the CollectAndCompare or GatherAndCompare functions. The
+// most appropriate use is not so much testing instrumentation of your code, but
+// testing custom prometheus.Collector implementations and in particular whole
+// exporters, i.e. programs that retrieve telemetry data from a 3rd party source
+// and convert it into Prometheus metrics.
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/internal"
+)
+
+// ToFloat64 collects all Metrics from the provided Collector. It expects that
+// this results in exactly one Metric being collected, which must be a Gauge,
+// Counter, or Untyped. In all other cases, ToFloat64 panics. ToFloat64 returns
+// the value of the collected Metric.
+//
+// The Collector provided is typically a simple instance of Gauge or Counter, or
+// – less commonly – a GaugeVec or CounterVec with exactly one element. But any
+// Collector fulfilling the prerequisites described above will do.
+//
+// Use this function with caution. It is computationally very expensive and thus
+// not suited at all to read values from Metrics in regular code. This is really
+// only for testing purposes, and even for testing, other approaches are often
+// more appropriate (see this package's documentation).
+//
+// A clear anti-pattern would be to use a metric type from the prometheus
+// package to track values that are also needed for something else than the
+// exposition of Prometheus metrics. For example, you would like to track the
+// number of items in a queue because your code should reject queuing further
+// items if a certain limit is reached. It is tempting to track the number of
+// items in a prometheus.Gauge, as it is then easily available as a metric for
+// exposition, too. However, then you would need to call ToFloat64 in your
+// regular code, potentially quite often. The recommended way is to track the
+// number of items conventionally (in the way you would have done it without
+// considering Prometheus metrics) and then expose the number with a
+// prometheus.GaugeFunc.
+func ToFloat64(c prometheus.Collector) float64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	m.Write(pb)
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Untyped != nil {
+		return pb.Untyped.GetValue()
+	}
+	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
+}
+
+// CollectAndCompare registers the provided Collector with a newly created
+// pedantic Registry. It then does the same as GatherAndCompare, gathering the
+// metrics from the pedantic Registry.
+func CollectAndCompare(c prometheus.Collector, expected io.Reader, metricNames ...string) error {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return fmt.Errorf("registering collector failed: %s", err)
+	}
+	return GatherAndCompare(reg, expected, metricNames...)
+}
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func GatherAndCompare(g prometheus.Gatherer, expected io.Reader, metricNames ...string) error {
+	got, err := g.Gather()
+	if err != nil {
+		return fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	var tp expfmt.TextParser
+	wantRaw, err := tp.TextToMetricFamilies(expected)
+	if err != nil {
+		return fmt.Errorf("parsing expected metrics failed: %s", err)
+	}
+	want := internal.NormalizeMetricFamilies(wantRaw)
+
+	return compare(got, want)
+}
+
+// compare encodes both provided slices of metric families into the text format,
+// compares their string message, and returns an error if they do not match.
+// The error contains the encoded text of both the desired and the actual
+// result.
+func compare(got, want []*dto.MetricFamily) error {
+	var gotBuf, wantBuf bytes.Buffer
+	enc := expfmt.NewEncoder(&gotBuf, expfmt.FmtText)
+	for _, mf := range got {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding gathered metrics failed: %s", err)
+		}
+	}
+	enc = expfmt.NewEncoder(&wantBuf, expfmt.FmtText)
+	for _, mf := range want {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding expected metrics failed: %s", err)
+		}
+	}
+
+	if wantBuf.String() != gotBuf.String() {
+		return fmt.Errorf(`
+metric output does not match expectation; want:
+
+%s
+got:
+
+%s`, wantBuf.String(), gotBuf.String())
+
+	}
+	return nil
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		for _, name := range names {
+			if m.GetName() == name {
+				filtered = append(filtered, m)
+				break
+			}
+		}
+	}
+	return filtered
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -162,6 +162,7 @@ github.com/pkg/errors
 ## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
+github.com/prometheus/client_golang/prometheus/testutil
 # github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.4.0


### PR DESCRIPTION
**What this PR does / why we need it**:

It is now possible to specify set the max size of the oci cache.
items in the cache are garbage collected if a certain threshold is reached.

Currently the threshold is set to 85% but we can think of providing that value as per cache configuration value.

Also moved the metrics to the new filesystem where these values are already tracked  in the index.
@hendrikKahl I added unit tests for the metrics but can you also check if the metrics are correct.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The size of the oci base and in-memory cache can now be restricted.
```
