### PR TITLE
implement integration tests for pushing a ctf to a registry

### DIFF
--- a/pkg/commands/ctf/ctf_suite_test.go
+++ b/pkg/commands/ctf/ctf_suite_test.go
@@ -5,13 +5,49 @@
 package ctf_test
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
 
+	"github.com/docker/cli/cli/config/types"
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/component-cli/ociclient"
+	"github.com/gardener/component-cli/ociclient/credentials"
+	"github.com/gardener/component-cli/ociclient/test/envtest"
 )
 
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CTF Test Suite")
 }
+
+var (
+	testenv *envtest.Environment
+	client  ociclient.ExtendedClient
+	keyring *credentials.GeneralOciKeyring
+)
+
+var _ = BeforeSuite(func() {
+	testenv = envtest.New(envtest.Options{
+		RegistryBinaryPath: filepath.Join("../../../", envtest.DefaultRegistryBinaryPath),
+		Stdout:             GinkgoWriter,
+		Stderr:             GinkgoWriter,
+	})
+	Expect(testenv.Start(context.Background())).To(Succeed())
+
+	keyring = credentials.New()
+	Expect(keyring.AddAuthConfig(testenv.Addr, types.AuthConfig{
+		Username: testenv.BasicAuth.Username,
+		Password: testenv.BasicAuth.Password,
+	})).To(Succeed())
+	var err error
+	client, err = ociclient.NewClient(logr.Discard(), ociclient.WithKeyring(keyring))
+	Expect(err).ToNot(HaveOccurred())
+}, 60)
+
+var _ = AfterSuite(func() {
+	Expect(testenv.Close()).To(Succeed())
+})

--- a/pkg/commands/ctf/push.go
+++ b/pkg/commands/ctf/push.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gardener/component-cli/pkg/utils"
 )
 
-type pushOptions struct {
+type PushOptions struct {
 	// CTFPath is the path to the directory containing the ctf archive.
 	CTFPath string
 	// BaseUrl is the repository context base url for all included component descriptors.
@@ -40,7 +40,7 @@ type pushOptions struct {
 
 // NewPushCommand creates a new definition command to push definitions
 func NewPushCommand(ctx context.Context) *cobra.Command {
-	opts := &pushOptions{}
+	opts := &PushOptions{}
 	cmd := &cobra.Command{
 		Use:   "push CTF_PATH",
 		Args:  cobra.ExactArgs(1),
@@ -72,7 +72,7 @@ Note: Currently only component archives are supoprted. Generic OCI Artifacts wil
 	return cmd
 }
 
-func (o *pushOptions) Run(ctx context.Context, log logr.Logger, fs vfs.FileSystem) error {
+func (o *PushOptions) Run(ctx context.Context, log logr.Logger, fs vfs.FileSystem) error {
 	info, err := fs.Stat(o.CTFPath)
 	if err != nil {
 		return fmt.Errorf("unable to get info for %s: %w", o.CTFPath, err)
@@ -132,7 +132,7 @@ It is expected that the given path points to a CTF Archive`, o.CTFPath)
 	return ctfArchive.Close()
 }
 
-func (o *pushOptions) Complete(args []string) error {
+func (o *PushOptions) Complete(args []string) error {
 	o.CTFPath = args[0]
 
 	var err error
@@ -149,14 +149,14 @@ func (o *pushOptions) Complete(args []string) error {
 }
 
 // Validate validates push options
-func (o *pushOptions) Validate() error {
+func (o *PushOptions) Validate() error {
 	if len(o.CTFPath) == 0 {
 		return errors.New("a path to the component descriptor must be defined")
 	}
 	return nil
 }
 
-func (o *pushOptions) AddFlags(fs *pflag.FlagSet) {
+func (o *PushOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.BaseUrl, "repo-ctx", "", "repository context url for component to upload. The repository url will be automatically added to the repository contexts.")
 	fs.StringArrayVarP(&o.AdditionalTags, "tag", "t", []string{}, "set additional tags on the oci artifact")
 

--- a/pkg/commands/ctf/push_test.go
+++ b/pkg/commands/ctf/push_test.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ctf_test
+
+import (
+	"context"
+	"os"
+
+	"github.com/gardener/component-spec/bindings-go/ctf"
+	cdoci "github.com/gardener/component-spec/bindings-go/oci"
+	"github.com/go-logr/logr"
+	"github.com/mandelsoft/vfs/pkg/layerfs"
+	"github.com/mandelsoft/vfs/pkg/memoryfs"
+	"github.com/mandelsoft/vfs/pkg/osfs"
+	"github.com/mandelsoft/vfs/pkg/projectionfs"
+	"github.com/mandelsoft/vfs/pkg/vfs"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/component-cli/ociclient/options"
+	"github.com/gardener/component-cli/pkg/commands/componentarchive"
+	"github.com/gardener/component-cli/pkg/commands/componentarchive/resources"
+	cmd "github.com/gardener/component-cli/pkg/commands/ctf"
+)
+
+var _ = Describe("Add", func() {
+
+	var testdataFs vfs.FileSystem
+
+	BeforeEach(func() {
+		baseFs, err := projectionfs.New(osfs.New(), "./testdata")
+		Expect(err).ToNot(HaveOccurred())
+		testdataFs = layerfs.New(memoryfs.New(), baseFs)
+	})
+
+	It("should push a component archive with a local file", func() {
+		baseFs, err := projectionfs.New(osfs.New(), "../componentarchive")
+		Expect(err).ToNot(HaveOccurred())
+		testdataFs = layerfs.New(memoryfs.New(), baseFs)
+		ctx := context.Background()
+
+		caOpts := &componentarchive.ComponentArchiveOptions{
+			CTFPath:        "/component.ctf",
+			ArchiveFormat:  ctf.ArchiveFormatTar,
+			ResourcesPaths: []string{"./resources/testdata/resources/21-res-dir.yaml"},
+		}
+		caOpts.ComponentArchivePath = "./testdata/00-ca"
+
+		Expect(caOpts.Run(ctx, logr.Discard(), testdataFs)).To(Succeed())
+
+		_, err = ctf.NewCTF(testdataFs, caOpts.CTFPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		cf, err := testenv.GetConfigFileBytes()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vfs.WriteFile(testdataFs, "/auth.json", cf, os.ModePerm))
+
+		opts := cmd.PushOptions{
+			CTFPath: "/component.ctf",
+			BaseUrl: testenv.Addr + "/test",
+			OciOptions: options.Options{
+				AllowPlainHttp:     false,
+				RegistryConfigPath: "/auth.json",
+			},
+		}
+		Expect(opts.Run(ctx, logr.Discard(), testdataFs)).To(Succeed())
+
+		repos, err := client.ListRepositories(ctx, testenv.Addr+"/test")
+		Expect(err).ToNot(HaveOccurred())
+
+		expectedRef := testenv.Addr + "/test/component-descriptors/example.com/component"
+		Expect(repos).To(ContainElement(Equal(expectedRef)))
+
+		manifest, err := client.GetManifest(ctx, expectedRef+":v0.0.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(manifest.Layers).To(HaveLen(2))
+		Expect(manifest.Layers[0].MediaType).To(Equal(cdoci.ComponentDescriptorTarMimeType),
+			"Expect that the first layer contains the component descriptor")
+		Expect(manifest.Layers[1].MediaType).To(Equal("application/x-tar"),
+			"Expect that the second layer contains the local blob")
+	})
+
+	It("should throw  an error if a local resource does not  exist", func() {
+		baseFs, err := projectionfs.New(osfs.New(), "../componentarchive")
+		Expect(err).ToNot(HaveOccurred())
+		testdataFs = layerfs.New(memoryfs.New(), baseFs)
+		ctx := context.Background()
+
+		resOpts := &resources.Options{
+			ResourceObjectPaths: []string{"./resources/testdata/resources/21-res-dir.yaml"},
+		}
+		resOpts.ComponentArchivePath = "./testdata/00-ca"
+		Expect(resOpts.Run(ctx, logr.Discard(), testdataFs)).To(Succeed())
+
+		// delete blobs
+		files, err := vfs.ReadDir(testdataFs, "./testdata/00-ca/blobs")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(files).To(HaveLen(1))
+		Expect(testdataFs.RemoveAll("./testdata/00-ca/blobs")).To(Succeed())
+		_, err = vfs.ReadDir(testdataFs, "./testdata/00-ca/blobs")
+		Expect(os.IsNotExist(err)).To(BeTrue(), "folder should not exist anymore")
+
+		caOpts := &componentarchive.ComponentArchiveOptions{
+			CTFPath:       "/component.ctf",
+			ArchiveFormat: ctf.ArchiveFormatTar,
+		}
+		caOpts.ComponentArchivePath = "./testdata/00-ca"
+		Expect(caOpts.Run(ctx, logr.Discard(), testdataFs)).To(Succeed())
+
+		_, err = ctf.NewCTF(testdataFs, caOpts.CTFPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		cf, err := testenv.GetConfigFileBytes()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(vfs.WriteFile(testdataFs, "/auth.json", cf, os.ModePerm))
+
+		opts := cmd.PushOptions{
+			CTFPath: "/component.ctf",
+			BaseUrl: testenv.Addr + "/test",
+			OciOptions: options.Options{
+				AllowPlainHttp:     false,
+				RegistryConfigPath: "/auth.json",
+			},
+		}
+		Expect(opts.Run(ctx, logr.Discard(), testdataFs)).To(HaveOccurred())
+	})
+
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Added integration test for the `ctf push` command:
- validates that  ctf with one. component archive and one. local artifact is correctly stored. int eh oci registry
- validates that an error is thrown if a local artifact does not exist

**Special notes for your reviewer**:

@enrico-kaack-comp can you check how to reproduce your issue with the local artifact.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
