### PR TITLE
prefer credHelpers entries over auths entries in docker config

### DIFF
--- a/ociclient/credentials/builder.go
+++ b/ociclient/credentials/builder.go
@@ -118,6 +118,15 @@ func (b *KeyringBuilder) Build() (*GeneralOciKeyring, error) {
 			return nil, err
 		}
 
+		// add native store for external program authentication
+		for address, helper := range dockerConfig.CredentialHelpers {
+			err := store.AddAuthConfigGetter(address, CredentialHelperAuthConfigGetter(b.log, dockerConfig, address, helper))
+			b.log.V(10).Info(fmt.Sprintf("added authentication for %q with credential helper %s", address, helper))
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		for address, dockerAuth := range dockerConfig.AuthConfigs {
 			auth := FromAuthConfig(dockerAuth)
 			// if the auth is empty use the default store to get the authentication
@@ -135,14 +144,6 @@ func (b *KeyringBuilder) Build() (*GeneralOciKeyring, error) {
 			}
 		}
 
-		// add native store for external program authentication
-		for address, helper := range dockerConfig.CredentialHelpers {
-			err := store.AddAuthConfigGetter(address, CredentialHelperAuthConfigGetter(b.log, dockerConfig, address, helper))
-			b.log.V(10).Info(fmt.Sprintf("added authentication for %q with credential helper %s", address, helper))
-			if err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	return store, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Problem: If in the docker config json, an "auths" as well as an "credHelpers" entry exists for the same registry, "auths" will be used preferrably over "credHelpers". This results in broken authentication, e.g. if for GCR an old token was stored once in the "auths" entry. The Docker CLI works correctly for these cases, because it prefers the "credHelpers" over the "auths" entry (see https://github.com/docker/cli/blob/master/docs/reference/commandline/cli.md#credential-store-options). 

Fix: The "credHelpers" entries are stored before the "auths" entries in the list of credential getters, then they will be used first during the lookup.

**Which issue(s) this PR fixes**:
Fixes #6 

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
