### PR TITLE
ref normalization

### DIFF
--- a/ociclient/client.go
+++ b/ociclient/client.go
@@ -328,7 +328,7 @@ func (c *client) getResolverForRef(ctx context.Context, ref string, scopes ...st
 func (c *client) ListTags(ctx context.Context, ref string) ([]string, error) {
 	refspec, err := oci.ParseRef(ref)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse reference: %w", err)
+		return nil, fmt.Errorf("unable to parse ref: %w", err)
 	}
 	hosts, err := c.getHostConfig(refspec.Host)
 	if err != nil {
@@ -423,7 +423,7 @@ func (c *client) ListRepositories(ctx context.Context, ref string) ([]string, er
 	// parse registry to also support more specific credentials e.g. for gcr with gcr.io/my-project
 	refspec, err := oci.ParseRef(ref)
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse reference: %w", err)
+		return nil, fmt.Errorf("unable to parse ref: %w", err)
 	}
 	repositories := make([]string, 0)
 	err = doRequestWithPaging(ctx, u, func(ctx context.Context, u *url.URL) (*http.Response, error) {

--- a/ociclient/client.go
+++ b/ociclient/client.go
@@ -117,6 +117,12 @@ func (c *client) InjectCache(cache cache.Cache) error {
 }
 
 func (c *client) Resolve(ctx context.Context, ref string) (name string, desc ocispecv1.Descriptor, err error) {
+	refspec, err := oci.ParseRef(ref)
+	if err != nil {
+		return "", ocispecv1.Descriptor{}, fmt.Errorf("unable to parse ref: %w", err)
+	}
+	ref = refspec.String()
+
 	resolver, err := c.getResolverForRef(ctx, ref, transport.PullScope)
 	if err != nil {
 		return "", ocispecv1.Descriptor{}, err
@@ -125,6 +131,12 @@ func (c *client) Resolve(ctx context.Context, ref string) (name string, desc oci
 }
 
 func (c *client) GetManifest(ctx context.Context, ref string) (*ocispecv1.Manifest, error) {
+	refspec, err := oci.ParseRef(ref)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse ref: %w", err)
+	}
+	ref = refspec.String()
+
 	resolver, err := c.getResolverForRef(ctx, ref, transport.PullScope)
 	if err != nil {
 		return nil, err
@@ -147,6 +159,12 @@ func (c *client) GetManifest(ctx context.Context, ref string) (*ocispecv1.Manife
 }
 
 func (c *client) Fetch(ctx context.Context, ref string, desc ocispecv1.Descriptor, writer io.Writer) error {
+	refspec, err := oci.ParseRef(ref)
+	if err != nil {
+		return fmt.Errorf("unable to parse ref: %w", err)
+	}
+	ref = refspec.String()
+
 	reader, err := c.getFetchReader(ctx, ref, desc)
 	if err != nil {
 		return err
@@ -199,6 +217,12 @@ func (c *client) getFetchReader(ctx context.Context, ref string, desc ocispecv1.
 }
 
 func (c *client) PushManifest(ctx context.Context, ref string, manifest *ocispecv1.Manifest, options ...PushOption) error {
+	refspec, err := oci.ParseRef(ref)
+	if err != nil {
+		return fmt.Errorf("unable to parse ref: %w", err)
+	}
+	ref = refspec.String()
+
 	opts := &PushOptions{}
 	opts.Store = c.cache
 	opts.ApplyOptions(options)


### PR DESCRIPTION
**What this PR does / why we need it**:
adds ref normalization to exported client methods. this is necessary for handling image refs to Docker Hub without hostnames (e.g. "busybox:latest").

also unifies error message when ref parsing fails

**Which issue(s) this PR fixes**:
Fixes #28

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
bugfix #28 
```
