### PR TITLE
add keymutex to lock parallel index lookup in the cache

### DIFF
--- a/ociclient/cache/filesystem.go
+++ b/ociclient/cache/filesystem.go
@@ -311,12 +311,16 @@ func (fs *FileSystem) RunGarbageCollection() {
 }
 
 type Index struct {
+	mut     sync.RWMutex
 	entries map[string]IndexEntry
 }
 
 // NewIndex creates a new index structure
 func NewIndex() Index {
-	return Index{entries: map[string]IndexEntry{}}
+	return Index{
+		mut:     sync.RWMutex{},
+		entries: map[string]IndexEntry{},
+	}
 }
 
 type IndexEntry struct {
@@ -333,7 +337,7 @@ type IndexEntry struct {
 }
 
 // Add adds a entry to the index.
-func (i Index) Add(name string, size int64, createdAt time.Time) {
+func (i *Index) Add(name string, size int64, createdAt time.Time) {
 	i.entries[name] = IndexEntry{
 		Name:               name,
 		Size:               size,
@@ -344,22 +348,28 @@ func (i Index) Add(name string, size int64, createdAt time.Time) {
 }
 
 // Len returns the number of items that are currently in the index.
-func (i Index) Len() int {
+func (i *Index) Len() int {
 	return len(i.entries)
 }
 
 // Get return the index entry with the given name.
-func (i Index) Get(name string) IndexEntry {
+func (i *Index) Get(name string) IndexEntry {
+	i.mut.RLock()
+	defer i.mut.RUnlock()
 	return i.entries[name]
 }
 
 // Remove removes the entry from the index.
-func (i Index) Remove(name string) {
+func (i *Index) Remove(name string) {
+	i.mut.Lock()
+	defer i.mut.Unlock()
 	delete(i.entries, name)
 }
 
 // Hit increases the hit count for the file.
-func (i Index) Hit(name string) {
+func (i *Index) Hit(name string) {
+	i.mut.Lock()
+	defer i.mut.Unlock()
 	entry, ok := i.entries[name]
 	if !ok {
 		return
@@ -371,7 +381,7 @@ func (i Index) Hit(name string) {
 
 // Reset resets the hit counter for all entries.
 // The reset preserves 20% if the old hits.
-func (i Index) Reset() {
+func (i *Index) Reset() {
 	for name := range i.entries {
 		entry := i.Get(name)
 
@@ -385,8 +395,8 @@ func (i Index) Reset() {
 }
 
 // DeepCopy creates a deep copy of the current index.
-func (i Index) DeepCopy() Index {
-	index := Index{
+func (i *Index) DeepCopy() *Index {
+	index := &Index{
 		entries: make(map[string]IndexEntry, len(i.entries)),
 	}
 	for key, value := range i.entries {
@@ -398,7 +408,7 @@ func (i Index) DeepCopy() Index {
 // PriorityList returns a entries of all entries
 // sorted by their gc priority.
 // The entry with the lowest priority is the first item.
-func (i Index) PriorityList() []IndexEntry {
+func (i *Index) PriorityList() []IndexEntry {
 	p := priorityList{
 		entries: make([]IndexEntry, 0),
 	}

--- a/ociclient/mock/client_mock.go
+++ b/ociclient/mock/client_mock.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	ociclient "github.com/gardener/component-cli/ociclient"
+	oci "github.com/gardener/component-cli/ociclient/oci"
 )
 
 // MockClient is a mock of Client interface.
@@ -67,6 +68,21 @@ func (mr *MockClientMockRecorder) GetManifest(arg0, arg1 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManifest", reflect.TypeOf((*MockClient)(nil).GetManifest), arg0, arg1)
 }
 
+// GetOCIArtifact mocks base method.
+func (m *MockClient) GetOCIArtifact(arg0 context.Context, arg1 string) (*oci.Artifact, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOCIArtifact", arg0, arg1)
+	ret0, _ := ret[0].(*oci.Artifact)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOCIArtifact indicates an expected call of GetOCIArtifact.
+func (mr *MockClientMockRecorder) GetOCIArtifact(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOCIArtifact", reflect.TypeOf((*MockClient)(nil).GetOCIArtifact), arg0, arg1)
+}
+
 // PushManifest mocks base method.
 func (m *MockClient) PushManifest(arg0 context.Context, arg1 string, arg2 *v1.Manifest, arg3 ...ociclient.PushOption) error {
 	m.ctrl.T.Helper()
@@ -84,6 +100,25 @@ func (mr *MockClientMockRecorder) PushManifest(arg0, arg1, arg2 interface{}, arg
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushManifest", reflect.TypeOf((*MockClient)(nil).PushManifest), varargs...)
+}
+
+// PushOCIArtifact mocks base method.
+func (m *MockClient) PushOCIArtifact(arg0 context.Context, arg1 string, arg2 *oci.Artifact, arg3 ...ociclient.PushOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PushOCIArtifact", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PushOCIArtifact indicates an expected call of PushOCIArtifact.
+func (mr *MockClientMockRecorder) PushOCIArtifact(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushOCIArtifact", reflect.TypeOf((*MockClient)(nil).PushOCIArtifact), varargs...)
 }
 
 // Resolve mocks base method.

--- a/ociclient/utils/keymutex/keymutex.go
+++ b/ociclient/utils/keymutex/keymutex.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keymutex
+
+import "sync"
+
+type KeyMutex struct {
+	mut     sync.Mutex
+	mutexes map[string]*sync.Mutex
+}
+
+// New creates a new key mutex
+func New() *KeyMutex {
+	return &KeyMutex{
+		mut:     sync.Mutex{},
+		mutexes: make(map[string]*sync.Mutex),
+	}
+}
+
+// Lock sets a lock on a specific key
+func (km *KeyMutex) Lock(key string) {
+	km.mut.Lock()
+	defer km.mut.Unlock()
+	mut, ok := km.mutexes[key]
+	if !ok {
+		km.mutexes[key] = &sync.Mutex{}
+		km.mutexes[key].Lock()
+		return
+	}
+	mut.Lock()
+}
+
+// Unlock removes a lock from a specific key
+func (km *KeyMutex) Unlock(key string) {
+	km.mut.Lock()
+	defer km.mut.Unlock()
+	if mut, ok := km.mutexes[key]; ok {
+		mut.Unlock()
+	}
+}
+
+// Remove removes a not needed mutex for a key.
+func (km *KeyMutex) Remove(key string) {
+	km.mut.Lock()
+	defer km.mut.Unlock()
+	delete(km.mutexes, key)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a concurrent map write on the index handling in the oci cache.
```
fatal error: concurrent map writes
fatal error: concurrent map writes
goroutine 223 [running]:
runtime.throw(0x1ba12ed, 0x15)
    /usr/local/Cellar/go/1.16/libexec/src/runtime/panic.go:1117 +0x72 fp=0xc0003cf7a0 sp=0xc0003cf770 pc=0x1036912
runtime.mapassign_faststr(0x1a86e60, 0xc00039aea0, 0xc0007d9777, 0x40, 0xc000ba8718)
    /usr/local/Cellar/go/1.16/libexec/src/runtime/map_faststr.go:291 +0x3d8 fp=0xc0003cf808 sp=0xc0003cf7a0 pc=0x1014258
github.com/gardener/component-cli/ociclient/cache.Index.Hit(...)
    /Users/d064518/code/component-cli/ociclient/cache/filesystem.go:369
github.com/gardener/component-cli/ociclient/cache.(*FileSystem).OpenFile(0xc0003166e0, 0xc0007d9777, 0x40, 0x0, 0xc0000001ff, 0x40, 0xc0000350c0, 0x31, 0xc0007d9770)
    /Users/d064518/code/component-cli/ociclient/cache/filesystem.go:233 +0x209 fp=0xc0003cf8e8 sp=0xc0003cf808 pc=0x1589a29
github.com/gardener/component-cli/ociclient/cache.(*layeredCache).get(0xc0004a4d80, 0xc0007d9777, 0x40, 0xc0000350c0, 0x31, 0xc0007d9770, 0x47, 0x20, 0x0, 0x0, ...)
    /Users/d064518/code/component-cli/ociclient/cache/cache.go:190 +0x3e8 fp=0xc0003cfad0 sp=0xc0003cf8e8 pc=0x1587588
github.com/gardener/component-cli/ociclient/cache.(*layeredCache).Get(0xc0004a4d80, 0xc0000350c0, 0x31, 0xc0007d9770, 0x47, 0x20, 0x0, 0x0, 0x0, 0x0, ...)
    /Users/d064518/code/component-cli/ociclient/cache/cache.go:118 +0xf9 fp=0xc0003cfbd8 sp=0xc0003cfad0 pc=0x1586d39
github.com/gardener/component-cli/ociclient.(*client).getFetchReader(0xc00009cde0, 0x1cfb338, 0xc00003a0b0, 0xc000bd2840, 0xad, 0xc0000350c0, 0x31, 0xc0007d9770, 0x47, 0x20, ...)
    /Users/d064518/code/component-cli/ociclient/client.go:376 +0x555 fp=0xc0003cfcb8 sp=0xc0003cfbd8 pc=0x198c7b5
github.com/gardener/component-cli/ociclient.(*client).Fetch(0xc00009cde0, 0x1cfb338, 0xc00003a0b0, 0xc000bd2840, 0xad, 0xc0000350c0, 0x31, 0xc0007d9770, 0x47, 0x20, ...)
    /Users/d064518/code/component-cli/ociclient/client.go:358 +0x238 fp=0xc0003cfe08 sp=0xc0003cfcb8 pc=0x198c038
github.com/gardener/component-cli/ociclient.Copy.func1(0x1cfb338, 0xc00003a0b0, 0xc0000350c0, 0x31, 0xc0007d9770, 0x47, 0x20, 0x0, 0x0, 0x0, ...)
    /Users/d064518/code/component-cli/ociclient/copy.go:25 +0xb2 fp=0xc0003cfeb0 sp=0xc0003cfe08 pc=0x1994372
github.com/gardener/component-cli/ociclient.GenericStore.Get.func1(0xc0007a0098, 0x1cfb338, 0xc00003a0b0, 0xc00050acc0, 0xc0000350c0, 0x31, 0xc0007d9770, 0x47, 0x20, 0x0, ...)
    /Users/d064518/code/component-cli/ociclient/copy.go:40 +0xe7 fp=0xc0003cff68 sp=0xc0003cfeb0 pc=0x19944a7
runtime.goexit()
    /usr/local/Cellar/go/1.16/libexec/src/runtime/asm_amd64.s:1371 +0x1 fp=0xc0003cff70 sp=0xc0003cff68 pc=0x106c541
created by github.com/gardener/component-cli/ociclient.GenericStore.Get
    /Users/d064518/code/component-cli/ociclient/copy.go:37 +0x1e8
goroutine 1 [select]:
net/http.(*persistConn).roundTrip(0xc00017d200, 0xc0004a4280, 0x0, 0x0, 0x0)
    /usr/local/Cellar/go/1.16/libexec/src/net/http/transport.go:2610 +0x765
net/http.(*Transport).roundTrip(0x22a57a0, 0xc00013a900, 0x1a51e60, 0xc000747c01, 0xc0005114a0)
    /usr/local/Cellar/go/1.16/libexec/src/net/http/transport.go:592 +0xacb
net/http.(*Transport).RoundTrip(0x22a57a0, 0xc00013a900, 0x1b98121, 0xa, 0xc000511528)
    /usr/local/Cellar/go/1.16/libexec/src/net/http/roundtrip.go:17 +0x35
github.com/google/go-containerregistry/pkg/v1/remote/transport.(*userAgentTransport).RoundTrip(0xc0002b79a0, 0xc00013a900, 0xe, 0xc00013a900, 0x1b94dc5)
    /Users/d064518/code/component-cli/vendor/github.com/google/go-containerregistry/pkg/v1/remote/transport/useragent.go:93 +0x125
github.com/google/go-containerregistry/pkg/v1/remote/transport.(*schemeTransport).RoundTrip(0xc0007b0b00, 0xc00013a900, 0xc0007b0b00, 0x0, 0x0)
    /Users/d064518/code/component-cli/vendor/github.com/google/go-containerregistry/pkg/v1/remote/transport/schemer.go:43 +0xa2
net/http.send(0xc00013a900, 0x1ce1dc0, 0xc0007b0b00, 0x0, 0x0, 0x0, 0xc0007a00e8, 0x18, 0x1, 0x0)
    /usr/local/Cellar/go/1.16/libexec/src/net/http/client.go:251 +0x454
net/http.(*Client).send(0xc000396480, 0xc00013a900, 0x0, 0x0, 0x0, 0xc0007a00e8, 0x0, 0x1, 0xc000627c20)
    /usr/local/Cellar/go/1.16/libexec/src/net/http/client.go:175 +0xff
net/http.(*Client).do(0xc000396480, 0xc00013a900, 0x0, 0x0, 0x0)
    /usr/local/Cellar/go/1.16/libexec/src/net/http/client.go:717 +0x45f
net/http.(*Client).Do(...)
    /usr/local/Cellar/go/1.16/libexec/src/net/http/client.go:585
golang.org/x/net/context/ctxhttp.Do(0x1cfb3a8, 0xc0003963f0, 0xc000396480, 0xc00013a800, 0x0, 0x0, 0x1cfb3a8)
    /Users/d064518/code/component-cli/vendor/golang.org/x/net/context/ctxhttp/ctxhttp.go:27 +0x10f
github.com/containerd/containerd/remotes/docker.(*request).do(0xc0002a9320, 0x1cfb3a8, 0xc0003962d0, 0xc00096f970, 0xc000970468, 0xc000970468)
    /Users/d064518/code/component-cli/vendor/github.com/containerd/containerd/remotes/docker/resolver.go:567 +0x585
github.com/containerd/containerd/remotes/docker.(*request).doWithRetries(0xc0002a9320, 0x1cfb3a8, 0xc0003962d0, 0x0, 0x0, 0x0, 0x0, 0xc0001a55f0, 0xc6)
    /Users/d064518/code/component-cli/vendor/github.com/containerd/containerd/remotes/docker/resolver.go:576 +0x46
github.com/containerd/containerd/remotes/docker.dockerPusher.push(0xc00007ecd0, 0xc00077262c, 0xb, 0x3f76838, 0xc000dfa8e8, 0x1cfb3a8, 0xc0003962d0, 0xc0000351c0, 0x31, 0xc0007d99f0, ...)
    /Users/d064518/code/component-cli/vendor/github.com/containerd/containerd/remotes/docker/pusher.go:118 +0x768
github.com/containerd/containerd/remotes/docker.dockerPusher.Push(0xc00007ecd0, 0xc00077262c, 0xb, 0x3f76838, 0xc000dfa8e8, 0x1cfb3a8, 0xc0003962a0, 0xc0000351c0, 0x31, 0xc0007d99f0, ...)
    /Users/d064518/code/component-cli/vendor/github.com/containerd/containerd/remotes/docker/pusher.go:65 +0x110
github.com/gardener/component-cli/ociclient.(*client).pushContent(0xc00009cde0, 0x1cfb3a8, 0xc00039ae70, 0x1ce3920, 0xc00050acc0, 0x1ce3860, 0xc00050b380, 0xc0000351c0, 0x31, 0xc0007d99f0, ...)
    /Users/d064518/code/component-cli/ociclient/client.go:719 +0x1b5
github.com/gardener/component-cli/ociclient.(*client).pushManifest(0xc00009cde0, 0x1cfb3a8, 0xc00039ae70, 0xc0007b2600, 0x1ce3860, 0xc00050b380, 0x1cf5210, 0xc0004a4d80, 0xc0003f43d0, 0x0, ...)
    /Users/d064518/code/component-cli/ociclient/client.go:290 +0x498
github.com/gardener/component-cli/ociclient.(*client).PushOCIArtifact(0xc00009cde0, 0x1cfb3a8, 0xc00039ae70, 0xc000747c20, 0x8f, 0xc0003f4370, 0xc0003f4380, 0x1, 0x1, 0xc000634000, ...)
    /Users/d064518/code/component-cli/ociclient/client.go:252 +0x485
github.com/gardener/component-cli/ociclient.Copy(0x1cfb3a8, 0xc00039ae70, 0x1cff5a0, 0xc00009cde0, 0xc0009beb00, 0xad, 0xc000da0510, 0x8f, 0x0, 0x0)
    /Users/d064518/code/component-cli/ociclient/copy.go:28 +0x2c2
github.com/gardener/component-cli/pkg/commands/componentarchive/remote.(*Copier).Copy(0xc0003a0f00, 0x1cfb3a8, 0xc00039ae70, 0xc0008c4e20, 0x1c, 0xc0001eeb48, 0x7, 0xc00019cd50, 0x8)
    /Users/d064518/code/component-cli/pkg/commands/componentarchive/remote/copy.go:320 +0x27de
github.com/gardener/component-cli/pkg/commands/componentarchive/remote.(*Copier).Copy(0xc0003a0f00, 0x1cfb3a8, 0xc00039ae70, 0xc0005c7dd0, 0x2e, 0xc00019cd50, 0x8, 0x7ffeefbff369, 0x8)
    /Users/d064518/code/component-cli/pkg/commands/componentarchive/remote/copy.go:222 +0x3132
github.com/gardener/component-cli/pkg/commands/componentarchive/remote.(*Copier).Copy(0xc0003a0f00, 0x1cfb3a8, 0xc00039ae70, 0x7ffeefbff32d, 0x3b, 0x7ffeefbff369, 0x8, 0x1cf5210, 0xc0004a4d80)
    /Users/d064518/code/component-cli/pkg/commands/componentarchive/remote/copy.go:222 +0x3132
github.com/gardener/component-cli/pkg/commands/componentarchive/remote.(*CopyOptions).Run(0xc0002c6370, 0x1cfb3a8, 0xc000525d40, 0x1cff5e8, 0xc00009e0f0, 0x1d0abe8, 0x22e2388, 0x0, 0x0)
    /Users/d064518/code/component-cli/pkg/commands/componentarchive/remote/copy.go:128 +0x4fe
github.com/gardener/component-cli/pkg/commands/componentarchive/remote.NewCopyCommand.func1(0xc000033340, 0xc0002c6630, 0x2, 0xb)
    /Users/d064518/code/component-cli/pkg/commands/componentarchive/remote/copy.go:93 +0xd1
github.com/spf13/cobra.(*Command).execute(0xc000033340, 0xc0002c6580, 0xb, 0xb, 0xc000033340, 0xc0002c6580)
    /Users/d064518/code/component-cli/vendor/github.com/spf13/cobra/command.go:863 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0xc00051a580, 0xc00003a0b0, 0xc00051a580, 0x0)
    /Users/d064518/code/component-cli/vendor/github.com/spf13/cobra/command.go:977 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
    /Users/d064518/code/component-cli/vendor/github.com/spf13/cobra/command.go:905
main.main()
    /Users/d064518/code/component-cli/cmd/component-cli/main.go:20 +0x73
goroutine 6 [chan receive]:
k8s.io/klog/v2.(*loggingT).flushDaemon(0x22b1fe0)
    /Users/d064518/code/component-cli/vendor/k8s.io/klog/v2/klog.go:1169 +0x8b
created by k8s.io/klog/v2.init.0
    /Users/d064518/code/component-cli/vendor/k8s.io/klog/v2/klog.go:417 +0xdf
goroutine 28 [runnable]:
net/http.(*persistConn).readLoop(0xc00017d200)
    /usr/local/Cellar/go/1.16/libexec/src/net/http/transport.go:2093 +0x266
created by net/http.(*Transport).dialConn
    /usr/local/Cellar/go/1.16/libexec/src/net/http/transport.go:1743 +0xc77
goroutine 29 [select]:
net/http.(*persistConn).writeLoop(0xc00017d200)
    /usr/local/Cellar/go/1.16/libexec/src/net/http/transport.go:2382 +0xf7
created by net/http.(*Transport).dialConn
    /usr/local/Cellar/go/1.16/libexec/src/net/http/transport.go:1744 +0xc9c
goroutine 1866 [IO wait]:
internal/poll.runtime_pollWait(0x3a05ba8, 0x72, 0xffffffffffffffff)
    /usr/local/Cellar/go/1.16/libexec/src/runtime/netpoll.go:222 +0x55
internal/poll.(*pollDesc).wait(0xc0003a0218, 0x72, 0xce00, 0xce61, 0xffffffffffffffff)
    /usr/local/Cellar/go/1.16/libexec/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
    /usr/local/Cellar/go/1.16/libexec/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc0003a0200, 0xc0009e6000, 0xce61, 0xce61, 0x0, 0x0, 0x0)
    /usr/local/Cellar/go/1.16/libexec/src/internal/poll/fd_unix.go:166 +0x1d5
net.(*netFD).Read(0xc0003a0200, 0xc0009e6000, 0xce61, 0xce61, 0x20300000000000, 0x400, 0x400)
    /usr/local/Cellar/go/1.16/libexec/src/net/fd_posix.go:55 +0x4f
net.(*conn).Read(0xc0003980a0, 0xc0009e6000, 0xce61, 0xce61, 0x0, 0x0, 0x0)
    /usr/local/Cellar/go/1.16/libexec/src/net/net.go:183 +0x91
crypto/tls.(*atLeastReader).Read(0xc000374198, 0xc0009e6000, 0xce61, 0xce61, 0xc0013659f8, 0xc000380900, 0x0)
    /usr/local/Cellar/go/1.16/libexec/src/crypto/tls/conn.go:776 +0x63
bytes.(*Buffer).ReadFrom(0xc0005c4278, 0x1ce1a00, 0xc000374198, 0x100b3a5, 0x1a9bcc0, 0x1b61800)
    /usr/local/Cellar/go/1.16/libexec/src/bytes/buffer.go:204 +0xbe
crypto/tls.(*Conn).readFromUntil(0xc0005c4000, 0x39cea18, 0xc0003980a0, 0x5, 0xc0003980a0, 0x203000)
    /usr/local/Cellar/go/1.16/libexec/src/crypto/tls/conn.go:798 +0xf3
crypto/tls.(*Conn).readRecordOrCCS(0xc0005c4000, 0x0, 0x0, 0x103961c)
    /usr/local/Cellar/go/1.16/libexec/src/crypto/tls/conn.go:605 +0x115
crypto/tls.(*Conn).readRecord(...)
    /usr/local/Cellar/go/1.16/libexec/src/crypto/tls/conn.go:573
crypto/tls.(*Conn).Read(0xc0005c4000, 0xc001016000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/local/Cellar/go/1.16/libexec/src/crypto/tls/conn.go:1276 +0x165
net/http.(*persistConn).Read(0xc001082b40, 0xc001016000, 0x1000, 0x1000, 0xc000044660, 0xc001365d40, 0x1005435)
    /usr/local/Cellar/go/1.16/libexec/src/net/http/transport.go:1922 +0x77
bufio.(*Reader).fill(0xc0002b8d20)
    /usr/local/Cellar/go/1.16/libexec/src/bufio/bufio.go:101 +0x108
bufio.(*Reader).Peek(0xc0002b8d20, 0x1, 0x0, 0x1, 0x4, 0x1, 0x3)
    /usr/local/Cellar/go/1.16/libexec/src/bufio/bufio.go:139 +0x4f
net/http.(*persistConn).readLoop(0xc001082b40)
    /usr/local/Cellar/go/1.16/libexec/src/net/http/transport.go:2083 +0x1a8
created by net/http.(*Transport).dialConn
    /usr/local/Cellar/go/1.16/libexec/src/net/http/transport.go:1743 +0xc77
goroutine 1867 [select]:
net/http.(*persistConn).writeLoop(0xc001082b40)
    /usr/local/Cellar/go/1.16/libexec/src/net/http/transport.go:2382 +0xf7
created by net/http.(*Transport).dialConn
    /usr/local/Cellar/go/1.16/libexec/src/net/http/transport.go:1744 +0xc9c
goroutine 224 [running]:
    goroutine running on other thread; stack unavailable
created by github.com/gardener/component-cli/ociclient.GenericStore.Get
    /Users/d064518/code/component-cli/ociclient/copy.go:37 +0x1e8
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
