### PR TITLE
improves error message in cache

### DIFF
--- a/ociclient/cache/cache.go
+++ b/ociclient/cache/cache.go
@@ -175,7 +175,7 @@ func (lc *layeredCache) get(dgst string, desc ocispecv1.Descriptor) (os.FileInfo
 		if err := lc.baseFs.Remove(dgst); err != nil {
 			lc.log.V(7).Info("unable to remove invalid blob", "digest", dgst, "err", err.Error())
 		}
-		return info, nil, ErrNotFound
+		return info, nil, ErrInvalidBlob
 	}
 	file, err := lc.baseFs.OpenFile(dgst, os.O_RDONLY, os.ModePerm)
 	if err != nil {
@@ -231,7 +231,7 @@ func (lc *layeredCache) getFromOverlay(dgst string, desc ocispecv1.Descriptor) (
 		if err := lc.overlayFs.Remove(dgst); err != nil {
 			lc.log.V(7).Info("unable to remove invalid blob", "digest", dgst, "err", err.Error())
 		}
-		return info, nil, ErrNotFound
+		return info, nil, ErrInvalidBlob
 	}
 	file, err := lc.overlayFs.OpenFile(dgst, os.O_RDONLY, os.ModePerm)
 	if err != nil {

--- a/ociclient/cache/cache_suite_test.go
+++ b/ociclient/cache/cache_suite_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Cache", func() {
 
 			_, err = c.Get(desc)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(Equal(ErrNotFound))
+			Expect(err).To(Equal(ErrInvalidBlob))
 		})
 
 		It("should detect tampered data (size shortcut) and remove the tempered blob", func() {
@@ -87,7 +87,7 @@ var _ = Describe("Cache", func() {
 
 			_, err = c.Get(desc)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(Equal(ErrNotFound))
+			Expect(err).To(Equal(ErrInvalidBlob))
 		})
 
 		Context("metrics", func() {

--- a/ociclient/cache/types.go
+++ b/ociclient/cache/types.go
@@ -14,8 +14,11 @@ import (
 )
 
 var (
-	// ErrNotFound is a error that indicates that the file is not cached
+	// ErrNotFound is an error that indicates that the file is not cached
 	ErrNotFound = errors.New("not cached")
+
+	// ErrInvalidBlob is an error that indicates that a blob is invalid
+	ErrInvalidBlob = errors.New("invalid blob")
 )
 
 // CacheDirEnvName is the name of the environment variable that configures cache directory.


### PR DESCRIPTION
**What this PR does / why we need it**:
improves error message in the cache. the "not cached" msg was misleading, as the actual error was that the blob content didn't match with the descriptor data

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
