### PR TITLE
set the insecure option when the host configuration scheme is "http" and "allowPlainHttp" is set to "true"

### DIFF
--- a/ociclient/client.go
+++ b/ociclient/client.go
@@ -432,9 +432,34 @@ func (c *client) getHttpClient() *http.Client {
 	}
 }
 
+// getRefParserOptions returns the options for reference parsing
+func (c *client) getRefParserOptions(ref string) ([]name.Option, error) {
+	hosts, err := c.getHostConfig(ref)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find registry host: %w", err)
+	}
+	if len(hosts) == 0 {
+		return nil, fmt.Errorf("no host configuration found: %w", err)
+	}
+
+	hostConfig := hosts[0]
+	var options []name.Option
+	if hostConfig.Scheme == "http" {
+		options = []name.Option{
+			name.Insecure,
+		}
+	}
+	return options, nil
+}
+
 // getTransportForRef returns the authenticated transport for a reference.
 func (c *client) getTransportForRef(ctx context.Context, ref string, scopes ...string) (http.RoundTripper, error) {
-	repo, err := name.ParseReference(ref)
+	parseOptions, err := c.getRefParserOptions(ref)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get ref parser options: %w", err)
+	}
+
+	repo, err := name.ParseReference(ref, parseOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse ref: %w", err)
 	}
@@ -529,7 +554,12 @@ func (c *client) ListTags(ctx context.Context, ref string) ([]string, error) {
 
 // ListRepositories lists all repositories for the given registry host.
 func (c *client) ListRepositories(ctx context.Context, ref string) ([]string, error) {
-	repo, err := name.ParseReference(ref)
+	parseOptions, err := c.getRefParserOptions(ref)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get ref parser options: %w", err)
+	}
+
+	repo, err := name.ParseReference(ref, parseOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse ref: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When using an oci reference to plain http repository which does not match

- localhost
- 127.0.0.1
- ::1
- RFC1918

the insecure option has to be set when `allowPlainHttp` is set to true (https://github.com/gardener/component-cli/blob/main/ociclient/client.go#L48)

**Which issue(s) this PR fixes**:
Fixes gardener/landscaper#329

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
