### PR TITLE
add cross build for darwin arm64

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -39,7 +39,7 @@ COMPONENT_DESCRIPTOR_FILE_PATH="$COMPONENT_ARCHIVE_PATH/component-descriptor.yam
 mkdir -p "$COMPONENT_ARCHIVE_PATH"
 cp "$BASE_DEFINITION_PATH" "$COMPONENT_DESCRIPTOR_FILE_PATH"
 
-build_matrix=("linux,amd64" "darwin,amd64" "windows,amd64")
+build_matrix=("linux,amd64" "darwin,amd64" "darwin,arm64" "windows,amd64")
 
 for i in "${build_matrix[@]}"; do
   IFS=',' read os arch <<< "${i}"

--- a/hack/cross-build.sh
+++ b/hack/cross-build.sh
@@ -15,7 +15,7 @@ fi
 
 mkdir -p dist
 
-build_matrix=("linux,amd64" "darwin,amd64" "windows,amd64")
+build_matrix=("linux,amd64" "darwin,amd64" "darwin,arm64" "windows,amd64")
 
 for i in "${build_matrix[@]}"; do
   IFS=',' read os arch <<< "${i}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add cross build for darwin arm64 to run natively on Apple M1 hardware.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added binary release for darwin arm64
```
