### PR TITLE
adds replace-oci-ref flag

### DIFF
--- a/docs/reference/component-cli_component-archive_remote_copy.md
+++ b/docs/reference/component-cli_component-archive_remote_copy.md
@@ -30,6 +30,7 @@ component-cli component-archive remote copy COMPONENT_NAME VERSION --from SOURCE
       --recursive                           Recursively copy the component descriptor and its references. (default true)
       --registry-config string              path to the dockerconfig.json with the oci registry authentication information
       --relative-urls                       converts all copied oci artifacts to relative urls
+      --replace-oci-ref strings             list of replace expressions in the format left:right. For every resource with accessType == ociRegistry, all occurences of 'left' in the target ref are replaced with 'right' before the upload
       --source-artifact-repository string   source repository where realtiove oci artifacts are copied from. This is only relevant if artifacts are copied by value and it will be defaulted to the source component repository
       --target-artifact-repository string   target repository where the artifacts are copied to. This is only relevant if artifacts are copied by value and it will be defaulted to the target component repository
       --to string                           target repository where the components are copied to.

--- a/pkg/commands/componentarchive/remote/copy.go
+++ b/pkg/commands/componentarchive/remote/copy.go
@@ -66,6 +66,9 @@ type CopyOptions struct {
 	// ConvertToRelativeOCIReferences configures the cli to write copied artifacts back with a relative reference
 	ConvertToRelativeOCIReferences bool
 
+	// ReplaceOCIRefs contains replace expressions for manipulating upload refs of resources with accessType == ociRegistry
+	ReplaceOCIRefs []string
+
 	// OciOptions contains all exposed options to configure the oci client.
 	OciOptions ociopts.Options
 }
@@ -110,6 +113,15 @@ func (o *CopyOptions) Run(ctx context.Context, log logr.Logger, fs vfs.FileSyste
 	}
 	defer cache.Close()
 
+	replaceOCIRefs := map[string]string{}
+	for _, replace := range o.ReplaceOCIRefs {
+		splittedReplace := strings.Split(replace, ":")
+		if len(splittedReplace) != 2 {
+			return fmt.Errorf("invalid replace expression %s: must have the format left:right", replace)
+		}
+		replaceOCIRefs[splittedReplace[0]] = splittedReplace[1]
+	}
+
 	c := Copier{
 		SrcRepoCtx:                     cdv2.NewOCIRegistryRepository(o.SourceRepository, ""),
 		TargetRepoCtx:                  cdv2.NewOCIRegistryRepository(o.TargetRepository, ""),
@@ -123,6 +135,7 @@ func (o *CopyOptions) Run(ctx context.Context, log logr.Logger, fs vfs.FileSyste
 		SourceArtifactRepository:       o.SourceArtifactRepository,
 		TargetArtifactRepository:       o.TargetArtifactRepository,
 		ConvertToRelativeOCIReferences: o.ConvertToRelativeOCIReferences,
+		ReplaceOCIRefs:                 replaceOCIRefs,
 	}
 
 	if err := c.Copy(ctx, o.ComponentName, o.ComponentVersion); err != nil {
@@ -178,6 +191,7 @@ func (o *CopyOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.SourceArtifactRepository, "source-artifact-repository", "",
 		"source repository where realtiove oci artifacts are copied from. This is only relevant if artifacts are copied by value and it will be defaulted to the source component repository")
 	fs.BoolVar(&o.ConvertToRelativeOCIReferences, "relative-urls", false, "converts all copied oci artifacts to relative urls")
+	fs.StringSliceVar(&o.ReplaceOCIRefs, "replace-oci-ref", []string{}, "list of replace expressions in the format left:right. For every resource with accessType == "+cdv2.OCIRegistryType+", all occurences of 'left' in the target ref are replaced with 'right' before the upload")
 	o.OciOptions.AddFlags(fs)
 }
 
@@ -206,6 +220,8 @@ type Copier struct {
 	TargetArtifactRepository string
 	// ConvertToRelativeOCIReferences configures the cli to write copied artifacts back with a relative reference
 	ConvertToRelativeOCIReferences bool
+	// ReplaceOCIRefs contains replace expressions for manipulating upload refs of resources with accessType == ociRegistry
+	ReplaceOCIRefs map[string]string
 }
 
 func (c *Copier) Copy(ctx context.Context, name, version string) error {
@@ -281,6 +297,11 @@ func (c *Copier) Copy(ctx context.Context, name, version string) error {
 			if err != nil {
 				return fmt.Errorf("unable to create target oci artifact reference for resource %s: %w", res.Name, err)
 			}
+
+			for old, new := range c.ReplaceOCIRefs {
+				target = strings.ReplaceAll(target, old, new)
+			}
+
 			log.V(4).Info(fmt.Sprintf("copy oci artifact %s to %s", ociRegistryAcc.ImageReference, target))
 			if err := ociclient.Copy(ctx, c.OciClient, ociRegistryAcc.ImageReference, target); err != nil {
 				return fmt.Errorf("unable to copy oci artifact %s from %s to %s: %w", res.Name, ociRegistryAcc.ImageReference, target, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
adds the "replace-oci-ref" flag to the "ca remote copy" command. the flag can be used for performing replacement operations on the refs of resources with accessType == ociRegistry before their upload.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- adds "replace-oci-ref" flag to "ca remote copy" command 
```
