### PR TITLE
filters package

### DIFF
--- a/pkg/transport/filters/access_type_filter.go
+++ b/pkg/transport/filters/access_type_filter.go
@@ -14,14 +14,12 @@ type AccessTypeFilterSpec struct {
 }
 
 type accessTypeFilter struct {
-	includeAccessTypes []string
+	includeAccessTypes map[string]bool
 }
 
 func (f accessTypeFilter) Matches(cd cdv2.ComponentDescriptor, r cdv2.Resource) bool {
-	for _, accessType := range f.includeAccessTypes {
-		if r.Access.Type == accessType {
-			return true
-		}
+	if _, ok := f.includeAccessTypes[r.Access.Type]; ok {
+		return true
 	}
 	return false
 }
@@ -33,7 +31,11 @@ func NewAccessTypeFilter(spec AccessTypeFilterSpec) (Filter, error) {
 	}
 
 	filter := accessTypeFilter{
-		includeAccessTypes: spec.IncludeAccessTypes,
+		includeAccessTypes: map[string]bool{},
+	}
+
+	for _, resourceType := range spec.IncludeAccessTypes {
+		filter.includeAccessTypes[resourceType] = true
 	}
 
 	return &filter, nil

--- a/pkg/transport/filters/access_type_filter.go
+++ b/pkg/transport/filters/access_type_filter.go
@@ -9,11 +9,15 @@ import (
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 )
 
-type resourceAccessTypeFilter struct {
+type AccessTypeFilterSpec struct {
+	IncludeAccessTypes []string `json:"includeAccessTypes"`
+}
+
+type accessTypeFilter struct {
 	includeAccessTypes []string
 }
 
-func (f resourceAccessTypeFilter) Matches(cd cdv2.ComponentDescriptor, r cdv2.Resource) bool {
+func (f accessTypeFilter) Matches(cd cdv2.ComponentDescriptor, r cdv2.Resource) bool {
 	for _, accessType := range f.includeAccessTypes {
 		if r.Access.Type == accessType {
 			return true
@@ -22,14 +26,14 @@ func (f resourceAccessTypeFilter) Matches(cd cdv2.ComponentDescriptor, r cdv2.Re
 	return false
 }
 
-// NewResourceAccessTypeFilter creates a new resourceAccessTypeFilter
-func NewResourceAccessTypeFilter(includeAccessTypes ...string) (Filter, error) {
-	if len(includeAccessTypes) == 0 {
+// NewAccessTypeFilter creates a new accessTypeFilter
+func NewAccessTypeFilter(spec AccessTypeFilterSpec) (Filter, error) {
+	if len(spec.IncludeAccessTypes) == 0 {
 		return nil, fmt.Errorf("includeAccessTypes must not be empty")
 	}
 
-	filter := resourceAccessTypeFilter{
-		includeAccessTypes: includeAccessTypes,
+	filter := accessTypeFilter{
+		includeAccessTypes: spec.IncludeAccessTypes,
 	}
 
 	return &filter, nil

--- a/pkg/transport/filters/component_name_filter.go
+++ b/pkg/transport/filters/component_name_filter.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+package filters
+
+import (
+	"fmt"
+	"regexp"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+)
+
+type componentNameFilter struct {
+	includeComponentNames []*regexp.Regexp
+}
+
+func (f componentNameFilter) Matches(cd cdv2.ComponentDescriptor, r cdv2.Resource) bool {
+	for _, icn := range f.includeComponentNames {
+		if icn.MatchString(cd.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+// NewComponentNameFilter creates a new componentNameFilter
+func NewComponentNameFilter(includeComponentNames ...string) (Filter, error) {
+	if len(includeComponentNames) == 0 {
+		return nil, fmt.Errorf("includeComponentNames must not be empty")
+	}
+
+	icnRegexps := []*regexp.Regexp{}
+	for _, icn := range includeComponentNames {
+		icnRegexp, err := regexp.Compile(icn)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse regexp %s: %w", icn, err)
+		}
+		icnRegexps = append(icnRegexps, icnRegexp)
+	}
+
+	filter := componentNameFilter{
+		includeComponentNames: icnRegexps,
+	}
+
+	return &filter, nil
+}

--- a/pkg/transport/filters/component_name_filter.go
+++ b/pkg/transport/filters/component_name_filter.go
@@ -10,6 +10,10 @@ import (
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 )
 
+type ComponentNameFilterSpec struct {
+	IncludeComponentNames []string
+}
+
 type componentNameFilter struct {
 	includeComponentNames []*regexp.Regexp
 }
@@ -24,13 +28,13 @@ func (f componentNameFilter) Matches(cd cdv2.ComponentDescriptor, r cdv2.Resourc
 }
 
 // NewComponentNameFilter creates a new componentNameFilter
-func NewComponentNameFilter(includeComponentNames ...string) (Filter, error) {
-	if len(includeComponentNames) == 0 {
+func NewComponentNameFilter(spec ComponentNameFilterSpec) (Filter, error) {
+	if len(spec.IncludeComponentNames) == 0 {
 		return nil, fmt.Errorf("includeComponentNames must not be empty")
 	}
 
 	icnRegexps := []*regexp.Regexp{}
-	for _, icn := range includeComponentNames {
+	for _, icn := range spec.IncludeComponentNames {
 		icnRegexp, err := regexp.Compile(icn)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse regexp %s: %w", icn, err)

--- a/pkg/transport/filters/filters_suite_test.go
+++ b/pkg/transport/filters/filters_suite_test.go
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+package filters_test
+
+import (
+	"testing"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	filter "github.com/gardener/component-cli/pkg/transport/filters"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Filters Test Suite")
+}
+
+var _ = Describe("filters", func() {
+
+	Context("resourceAccessTypeFilter", func() {
+
+		It("should match if access type is in include list", func() {
+			cd := cdv2.ComponentDescriptor{}
+			res := cdv2.Resource{
+				Access: cdv2.NewEmptyUnstructured(cdv2.OCIRegistryType),
+			}
+
+			f, err := filter.NewResourceAccessTypeFilter(cdv2.OCIRegistryType)
+			Expect(err).ToNot(HaveOccurred())
+
+			actualMatch := f.Matches(cd, res)
+			Expect(actualMatch).To(Equal(true))
+		})
+
+		It("should not match if access type is not in include list", func() {
+			cd := cdv2.ComponentDescriptor{}
+			res := cdv2.Resource{
+				Access: cdv2.NewEmptyUnstructured(cdv2.OCIRegistryType),
+			}
+
+			f, err := filter.NewResourceAccessTypeFilter(cdv2.LocalOCIBlobType)
+			Expect(err).ToNot(HaveOccurred())
+
+			actualMatch := f.Matches(cd, res)
+			Expect(actualMatch).To(Equal(false))
+		})
+
+		It("should return error upon creation if include list is empty", func() {
+			includeAccessTypes := []string{}
+			_, err := filter.NewResourceAccessTypeFilter(includeAccessTypes...)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("includeAccessTypes must not be empty"))
+		})
+
+	})
+
+	Context("resourceTypeFilter", func() {
+
+		It("should match if resource type is in include list", func() {
+			cd := cdv2.ComponentDescriptor{}
+			res := cdv2.Resource{
+				IdentityObjectMeta: cdv2.IdentityObjectMeta{
+					Name:    "my-res",
+					Version: "v0.1.0",
+					Type:    cdv2.OCIImageType,
+				},
+			}
+
+			f, err := filter.NewResourceTypeFilter(cdv2.OCIImageType)
+			Expect(err).ToNot(HaveOccurred())
+
+			actualMatch := f.Matches(cd, res)
+			Expect(actualMatch).To(Equal(true))
+		})
+
+		It("should not match if resource type is not in include list", func() {
+			cd := cdv2.ComponentDescriptor{}
+			res := cdv2.Resource{
+				IdentityObjectMeta: cdv2.IdentityObjectMeta{
+					Name:    "my-res",
+					Version: "v0.1.0",
+					Type:    "helm",
+				},
+			}
+
+			f, err := filter.NewResourceTypeFilter(cdv2.OCIImageType)
+			Expect(err).ToNot(HaveOccurred())
+
+			actualMatch := f.Matches(cd, res)
+			Expect(actualMatch).To(Equal(false))
+		})
+
+		It("should return error upon creation if include list is empty", func() {
+			includeResourceTypes := []string{}
+			_, err := filter.NewResourceTypeFilter(includeResourceTypes...)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("includeResourceTypes must not be empty"))
+		})
+
+	})
+
+	Context("componentNameFilter", func() {
+
+		It("should match if component name is in include list", func() {
+			cd := cdv2.ComponentDescriptor{
+				ComponentSpec: cdv2.ComponentSpec{
+					ObjectMeta: cdv2.ObjectMeta{
+						Name: "github.com/test/my-component",
+					},
+				},
+			}
+			res := cdv2.Resource{}
+
+			f1, err := filter.NewComponentNameFilter("github.com/test/my-component")
+			Expect(err).ToNot(HaveOccurred())
+
+			match1 := f1.Matches(cd, res)
+			Expect(match1).To(Equal(true))
+
+			f2, err := filter.NewComponentNameFilter("github.com/test/*")
+			Expect(err).ToNot(HaveOccurred())
+
+			match2 := f2.Matches(cd, res)
+			Expect(match2).To(Equal(true))
+		})
+
+		It("should not match if component name is not in include list", func() {
+			cd := cdv2.ComponentDescriptor{
+				ComponentSpec: cdv2.ComponentSpec{
+					ObjectMeta: cdv2.ObjectMeta{
+						Name: "github.com/test/my-component",
+					},
+				},
+			}
+			res := cdv2.Resource{}
+
+			f1, err := filter.NewComponentNameFilter("github.com/test/my-other-component")
+			Expect(err).ToNot(HaveOccurred())
+
+			match1 := f1.Matches(cd, res)
+			Expect(match1).To(Equal(false))
+
+			f2, err := filter.NewComponentNameFilter("github.com/test-2/*")
+			Expect(err).ToNot(HaveOccurred())
+
+			match2 := f2.Matches(cd, res)
+			Expect(match2).To(Equal(false))
+		})
+
+		It("should return error upon creation if include list is empty", func() {
+			includeComponentNames := []string{}
+			_, err := filter.NewComponentNameFilter(includeComponentNames...)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("includeComponentNames must not be empty"))
+		})
+
+		It("should return error upon creation if regexp is invalid", func() {
+			_, err := filter.NewComponentNameFilter("github.com/\\")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error parsing regexp"))
+		})
+
+	})
+
+})

--- a/pkg/transport/filters/filters_suite_test.go
+++ b/pkg/transport/filters/filters_suite_test.go
@@ -20,15 +20,20 @@ func TestConfig(t *testing.T) {
 
 var _ = Describe("filters", func() {
 
-	Context("resourceAccessTypeFilter", func() {
+	Context("accessTypeFilter", func() {
 
 		It("should match if access type is in include list", func() {
 			cd := cdv2.ComponentDescriptor{}
 			res := cdv2.Resource{
 				Access: cdv2.NewEmptyUnstructured(cdv2.OCIRegistryType),
 			}
+			spec := filter.AccessTypeFilterSpec{
+				IncludeAccessTypes: []string{
+					cdv2.OCIRegistryType,
+				},
+			}
 
-			f, err := filter.NewResourceAccessTypeFilter(cdv2.OCIRegistryType)
+			f, err := filter.NewAccessTypeFilter(spec)
 			Expect(err).ToNot(HaveOccurred())
 
 			actualMatch := f.Matches(cd, res)
@@ -40,8 +45,13 @@ var _ = Describe("filters", func() {
 			res := cdv2.Resource{
 				Access: cdv2.NewEmptyUnstructured(cdv2.OCIRegistryType),
 			}
+			spec := filter.AccessTypeFilterSpec{
+				IncludeAccessTypes: []string{
+					cdv2.LocalOCIBlobType,
+				},
+			}
 
-			f, err := filter.NewResourceAccessTypeFilter(cdv2.LocalOCIBlobType)
+			f, err := filter.NewAccessTypeFilter(spec)
 			Expect(err).ToNot(HaveOccurred())
 
 			actualMatch := f.Matches(cd, res)
@@ -49,8 +59,10 @@ var _ = Describe("filters", func() {
 		})
 
 		It("should return error upon creation if include list is empty", func() {
-			includeAccessTypes := []string{}
-			_, err := filter.NewResourceAccessTypeFilter(includeAccessTypes...)
+			spec := filter.AccessTypeFilterSpec{
+				IncludeAccessTypes: []string{},
+			}
+			_, err := filter.NewAccessTypeFilter(spec)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("includeAccessTypes must not be empty"))
 		})
@@ -68,8 +80,13 @@ var _ = Describe("filters", func() {
 					Type:    cdv2.OCIImageType,
 				},
 			}
+			spec := filter.ResourceTypeFilterSpec{
+				IncludeResourceTypes: []string{
+					cdv2.OCIImageType,
+				},
+			}
 
-			f, err := filter.NewResourceTypeFilter(cdv2.OCIImageType)
+			f, err := filter.NewResourceTypeFilter(spec)
 			Expect(err).ToNot(HaveOccurred())
 
 			actualMatch := f.Matches(cd, res)
@@ -85,8 +102,13 @@ var _ = Describe("filters", func() {
 					Type:    "helm",
 				},
 			}
+			spec := filter.ResourceTypeFilterSpec{
+				IncludeResourceTypes: []string{
+					cdv2.OCIImageType,
+				},
+			}
 
-			f, err := filter.NewResourceTypeFilter(cdv2.OCIImageType)
+			f, err := filter.NewResourceTypeFilter(spec)
 			Expect(err).ToNot(HaveOccurred())
 
 			actualMatch := f.Matches(cd, res)
@@ -94,8 +116,10 @@ var _ = Describe("filters", func() {
 		})
 
 		It("should return error upon creation if include list is empty", func() {
-			includeResourceTypes := []string{}
-			_, err := filter.NewResourceTypeFilter(includeResourceTypes...)
+			spec := filter.ResourceTypeFilterSpec{
+				IncludeResourceTypes: []string{},
+			}
+			_, err := filter.NewResourceTypeFilter(spec)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("includeResourceTypes must not be empty"))
 		})
@@ -113,14 +137,24 @@ var _ = Describe("filters", func() {
 				},
 			}
 			res := cdv2.Resource{}
+			spec := filter.ComponentNameFilterSpec{
+				IncludeComponentNames: []string{
+					"github.com/test/my-component",
+				},
+			}
 
-			f1, err := filter.NewComponentNameFilter("github.com/test/my-component")
+			f1, err := filter.NewComponentNameFilter(spec)
 			Expect(err).ToNot(HaveOccurred())
 
 			match1 := f1.Matches(cd, res)
 			Expect(match1).To(Equal(true))
 
-			f2, err := filter.NewComponentNameFilter("github.com/test/*")
+			spec = filter.ComponentNameFilterSpec{
+				IncludeComponentNames: []string{
+					"github.com/test/*",
+				},
+			}
+			f2, err := filter.NewComponentNameFilter(spec)
 			Expect(err).ToNot(HaveOccurred())
 
 			match2 := f2.Matches(cd, res)
@@ -136,14 +170,24 @@ var _ = Describe("filters", func() {
 				},
 			}
 			res := cdv2.Resource{}
+			spec := filter.ComponentNameFilterSpec{
+				IncludeComponentNames: []string{
+					"github.com/test/my-other-component",
+				},
+			}
 
-			f1, err := filter.NewComponentNameFilter("github.com/test/my-other-component")
+			f1, err := filter.NewComponentNameFilter(spec)
 			Expect(err).ToNot(HaveOccurred())
 
 			match1 := f1.Matches(cd, res)
 			Expect(match1).To(Equal(false))
 
-			f2, err := filter.NewComponentNameFilter("github.com/test-2/*")
+			spec = filter.ComponentNameFilterSpec{
+				IncludeComponentNames: []string{
+					"github.com/test-2/*",
+				},
+			}
+			f2, err := filter.NewComponentNameFilter(spec)
 			Expect(err).ToNot(HaveOccurred())
 
 			match2 := f2.Matches(cd, res)
@@ -151,14 +195,21 @@ var _ = Describe("filters", func() {
 		})
 
 		It("should return error upon creation if include list is empty", func() {
-			includeComponentNames := []string{}
-			_, err := filter.NewComponentNameFilter(includeComponentNames...)
+			spec := filter.ComponentNameFilterSpec{
+				IncludeComponentNames: []string{},
+			}
+			_, err := filter.NewComponentNameFilter(spec)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("includeComponentNames must not be empty"))
 		})
 
 		It("should return error upon creation if regexp is invalid", func() {
-			_, err := filter.NewComponentNameFilter("github.com/\\")
+			spec := filter.ComponentNameFilterSpec{
+				IncludeComponentNames: []string{
+					"github.com/\\",
+				},
+			}
+			_, err := filter.NewComponentNameFilter(spec)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("error parsing regexp"))
 		})

--- a/pkg/transport/filters/resource_access_type_filter.go
+++ b/pkg/transport/filters/resource_access_type_filter.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+package filters
+
+import (
+	"fmt"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+)
+
+type resourceAccessTypeFilter struct {
+	includeAccessTypes []string
+}
+
+func (f resourceAccessTypeFilter) Matches(cd cdv2.ComponentDescriptor, r cdv2.Resource) bool {
+	for _, accessType := range f.includeAccessTypes {
+		if r.Access.Type == accessType {
+			return true
+		}
+	}
+	return false
+}
+
+// NewResourceAccessTypeFilter creates a new resourceAccessTypeFilter
+func NewResourceAccessTypeFilter(includeAccessTypes ...string) (Filter, error) {
+	if len(includeAccessTypes) == 0 {
+		return nil, fmt.Errorf("includeAccessTypes must not be empty")
+	}
+
+	filter := resourceAccessTypeFilter{
+		includeAccessTypes: includeAccessTypes,
+	}
+
+	return &filter, nil
+}

--- a/pkg/transport/filters/resource_type_filter.go
+++ b/pkg/transport/filters/resource_type_filter.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+package filters
+
+import (
+	"fmt"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+)
+
+type resourceTypeFilter struct {
+	includeResourceTypes []string
+}
+
+func (f resourceTypeFilter) Matches(cd cdv2.ComponentDescriptor, r cdv2.Resource) bool {
+	for _, resourceType := range f.includeResourceTypes {
+		if r.Type == resourceType {
+			return true
+		}
+	}
+	return false
+}
+
+// NewResourceTypeFilter creates a new resourceTypeFilter
+func NewResourceTypeFilter(includeResourceTypes ...string) (Filter, error) {
+	if len(includeResourceTypes) == 0 {
+		return nil, fmt.Errorf("includeResourceTypes must not be empty")
+	}
+
+	filter := resourceTypeFilter{
+		includeResourceTypes: includeResourceTypes,
+	}
+
+	return &filter, nil
+}

--- a/pkg/transport/filters/resource_type_filter.go
+++ b/pkg/transport/filters/resource_type_filter.go
@@ -14,14 +14,12 @@ type ResourceTypeFilterSpec struct {
 }
 
 type resourceTypeFilter struct {
-	includeResourceTypes []string
+	includeResourceTypes map[string]bool
 }
 
 func (f resourceTypeFilter) Matches(cd cdv2.ComponentDescriptor, r cdv2.Resource) bool {
-	for _, resourceType := range f.includeResourceTypes {
-		if r.Type == resourceType {
-			return true
-		}
+	if _, ok := f.includeResourceTypes[r.Type]; ok {
+		return true
 	}
 	return false
 }
@@ -33,7 +31,11 @@ func NewResourceTypeFilter(spec ResourceTypeFilterSpec) (Filter, error) {
 	}
 
 	filter := resourceTypeFilter{
-		includeResourceTypes: spec.IncludeResourceTypes,
+		includeResourceTypes: map[string]bool{},
+	}
+
+	for _, resourceType := range spec.IncludeResourceTypes {
+		filter.includeResourceTypes[resourceType] = true
 	}
 
 	return &filter, nil

--- a/pkg/transport/filters/resource_type_filter.go
+++ b/pkg/transport/filters/resource_type_filter.go
@@ -9,6 +9,10 @@ import (
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 )
 
+type ResourceTypeFilterSpec struct {
+	IncludeResourceTypes []string `json:"includeResourceTypes"`
+}
+
 type resourceTypeFilter struct {
 	includeResourceTypes []string
 }
@@ -23,13 +27,13 @@ func (f resourceTypeFilter) Matches(cd cdv2.ComponentDescriptor, r cdv2.Resource
 }
 
 // NewResourceTypeFilter creates a new resourceTypeFilter
-func NewResourceTypeFilter(includeResourceTypes ...string) (Filter, error) {
-	if len(includeResourceTypes) == 0 {
+func NewResourceTypeFilter(spec ResourceTypeFilterSpec) (Filter, error) {
+	if len(spec.IncludeResourceTypes) == 0 {
 		return nil, fmt.Errorf("includeResourceTypes must not be empty")
 	}
 
 	filter := resourceTypeFilter{
-		includeResourceTypes: includeResourceTypes,
+		includeResourceTypes: spec.IncludeResourceTypes,
 	}
 
 	return &filter, nil

--- a/pkg/transport/filters/types.go
+++ b/pkg/transport/filters/types.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+package filters
+
+import (
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+)
+
+// Filter defines the interface for matching component resources with downloaders, processing rules, and uploaders
+type Filter interface {
+	// Matches matches a component descriptor and a resource against the filter
+	Matches(cdv2.ComponentDescriptor, cdv2.Resource) bool
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
adds the filters package for the new transport command. filters are used for matching the resources in the transported component descriptor(s) to downloaders, processing rules, and uploaders. the filters will be defined by an end user in the transport.config file.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
- adds filters package
```
