### PR TITLE
prevent DATA RACE error in tests in test environment

### DIFF
--- a/ociclient/test/envtest/envtest.go
+++ b/ociclient/test/envtest/envtest.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/docker/cli/cli/config/configfile"
@@ -45,6 +46,7 @@ type Environment struct {
 
 	cancelCtx context.CancelFunc
 	cmd       *exec.Cmd
+	mu        *sync.RWMutex
 	stopped   bool
 	err       error
 }
@@ -90,6 +92,7 @@ func New(opts Options) *Environment {
 		ReadinessTimeout:      *opts.ReadinessTimeout,
 		Stdout:                opts.Stdout,
 		Stderr:                opts.Stderr,
+		mu:                    &sync.RWMutex{},
 	}
 }
 
@@ -117,14 +120,19 @@ func (e *Environment) Start(ctx context.Context) error {
 }
 
 func (e *Environment) Close() error {
+	e.mu.RLock()
 	if !e.stopped {
 		e.cancelCtx()
 	}
+	e.mu.RUnlock()
 	// wait until the process is stopped.
 	for {
+		e.mu.RLock()
 		if e.stopped {
+			e.mu.RUnlock()
 			break
 		}
+		e.mu.RUnlock()
 		time.Sleep(2 * time.Second)
 	}
 
@@ -235,6 +243,8 @@ func (e *Environment) runRegistry(ctx context.Context) error {
 	e.Addr = e.RegistryConfiguration.HTTPConfig.Addr
 	go func() {
 		defer func() {
+			e.mu.Lock()
+			defer e.mu.Unlock()
 			e.stopped = true
 		}()
 		if err := e.cmd.Wait(); err != nil {

--- a/ociclient/test/envtest/envtest.go
+++ b/ociclient/test/envtest/envtest.go
@@ -128,11 +128,11 @@ func (e *Environment) Close() error {
 	// wait until the process is stopped.
 	for {
 		e.mu.RLock()
-		if e.stopped {
-			e.mu.RUnlock()
+		stopped := e.stopped
+		e.mu.RUnlock()
+		if stopped {
 			break
 		}
-		e.mu.RUnlock()
 		time.Sleep(2 * time.Second)
 	}
 
@@ -244,8 +244,8 @@ func (e *Environment) runRegistry(ctx context.Context) error {
 	go func() {
 		defer func() {
 			e.mu.Lock()
-			defer e.mu.Unlock()
 			e.stopped = true
+			e.mu.Unlock()
 		}()
 		if err := e.cmd.Wait(); err != nil {
 			if ctx.Err() == context.Canceled {


### PR DESCRIPTION
**What this PR does / why we need it**:

I'm using this test environment for https://github.com/gardener/landscaper/pull/388 and when running `make test`, I get this error (and the command returns with an error code, despite all tests being successful):

```
WARNING: DATA RACE
Write at 0x00c0005595e8 by goroutine 58:
  github.com/gardener/component-cli/ociclient/test/envtest.(*Environment).runRegistry.func1.1()
      /Users/d073016/go/src/github.com/gardener/landscaper/vendor/github.com/gardener/component-cli/ociclient/test/envtest/envtest.go:238 +0x39
  github.com/gardener/component-cli/ociclient/test/envtest.(*Environment).runRegistry.func1()
      /Users/d073016/go/src/github.com/gardener/landscaper/vendor/github.com/gardener/component-cli/ociclient/test/envtest/envtest.go:242 +0x2c1

Previous read at 0x00c0005595e8 by goroutine 50:
  github.com/gardener/component-cli/ociclient/test/envtest.(*Environment).Close()
      /Users/d073016/go/src/github.com/gardener/landscaper/vendor/github.com/gardener/component-cli/ociclient/test/envtest/envtest.go:125 +0xa4
...
```
As far as I understand, Golang seems to have a problem with concurrent read/write operations on the `stopped` boolean of the test environment struct.
I don't understand why a boolean is causing trouble - reading and writing it should be atomic, shouldn't it? - but wrapping it in a mutex seems to resolve the problem.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
