### PR TITLE
Fix image index copy

### DIFF
--- a/ociclient/client.go
+++ b/ociclient/client.go
@@ -291,7 +291,7 @@ func (c *client) PushBlob(ctx context.Context, ref string, desc ocispecv1.Descri
 	return nil
 }
 
-func (c *client) PushManifestRaw(ctx context.Context, ref string, desc ocispecv1.Descriptor, rawManifest []byte, options ...PushOption) error {
+func (c *client) PushRawManifest(ctx context.Context, ref string, desc ocispecv1.Descriptor, rawManifest []byte, options ...PushOption) error {
 	if !IsSingleArchImage(desc.MediaType) && !IsMultiArchImage(desc.MediaType) {
 		return fmt.Errorf("media type is not an image manifest or image index: %s", desc.MediaType)
 	}
@@ -361,7 +361,7 @@ func (c *client) PushManifestRaw(ctx context.Context, ref string, desc ocispecv1
 	return nil
 }
 
-func (c *client) GetManifestRaw(ctx context.Context, ref string) (ocispecv1.Descriptor, []byte, error) {
+func (c *client) GetRawManifest(ctx context.Context, ref string) (ocispecv1.Descriptor, []byte, error) {
 	refspec, err := oci.ParseRef(ref)
 	if err != nil {
 		return ocispecv1.Descriptor{}, nil, fmt.Errorf("unable to parse ref: %w", err)
@@ -491,7 +491,7 @@ func (c *client) pushImageIndex(ctx context.Context, indexArtifact *oci.Index, p
 }
 
 func (c *client) GetManifest(ctx context.Context, ref string) (*ocispecv1.Manifest, error) {
-	desc, rawManifest, err := c.GetManifestRaw(ctx, ref)
+	desc, rawManifest, err := c.GetRawManifest(ctx, ref)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get manifest: %w", err)
 	}
@@ -583,7 +583,7 @@ func (c *client) PushManifest(ctx context.Context, ref string, manifest *ocispec
 		Annotations: manifest.Annotations,
 	}
 
-	return c.PushManifestRaw(ctx, ref, desc, manifestBytes, options...)
+	return c.PushRawManifest(ctx, ref, desc, manifestBytes, options...)
 }
 
 func (c *client) getHttpClient() *http.Client {

--- a/ociclient/client_test.go
+++ b/ociclient/client_test.go
@@ -189,6 +189,9 @@ var _ = Describe("client", func() {
 			}
 		}, 20)
 
+		// TODO: write copy test with manifest list mediatype
+		// TODO: compare checksums of copied artifacts
+
 	})
 
 	Context("ExtendedClient", func() {

--- a/ociclient/client_test.go
+++ b/ociclient/client_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gardener/component-cli/pkg/testutils"
 )
 
-func RunPushAndPullImageTest(repository, manifestMediaType string) {
+func RunPushAndPullImageTest(ref, manifestMediaType string) {
 	ctx := context.Background()
 	defer ctx.Done()
 
@@ -34,7 +34,6 @@ func RunPushAndPullImageTest(repository, manifestMediaType string) {
 		[]byte("layer-1-data"),
 		[]byte("layer-2-data"),
 	}
-	ref := fmt.Sprintf("%s/%s", testenv.Addr, repository)
 
 	manifestDesc, manifestBytes := testutils.UploadTestImage(ctx, client, ref, manifestMediaType, configData, layersData)
 
@@ -113,7 +112,7 @@ var _ = Describe("client", func() {
 	Context("Client", func() {
 
 		It("should push and pull a single architecture image without modifications (oci media type)", func() {
-			ref := fmt.Sprintf("%s/%s", testenv.Addr, "single-arch-tests/0/artifact:0.0.1")
+			ref := fmt.Sprintf("%s/%s", testenv.Addr, "single-arch-tests/0/artifact:v0.0.1")
 			RunPushAndPullImageTest(ref, ocispecv1.MediaTypeImageManifest)
 		}, 20)
 

--- a/ociclient/copy.go
+++ b/ociclient/copy.go
@@ -18,7 +18,7 @@ import (
 // The artifact is copied without any modification.
 // This function does directly stream the blobs from the upstream it does not use any cache.
 func Copy(ctx context.Context, client Client, srcRef, tgtRef string) error {
-	desc, rawManifest, err := client.GetManifestRaw(ctx, srcRef)
+	desc, rawManifest, err := client.GetRawManifest(ctx, srcRef)
 	if err != nil {
 		return fmt.Errorf("unable to get manifest: %w", err)
 	}
@@ -39,13 +39,13 @@ func Copy(ctx context.Context, client Client, srcRef, tgtRef string) error {
 				return fmt.Errorf("unable to get manifest: %w", err)
 			}
 
-			if err := client.PushManifestRaw(ctx, tgtRef, manifestDesc, buf.Bytes(), WithStore(store)); err != nil {
+			if err := client.PushRawManifest(ctx, tgtRef, manifestDesc, buf.Bytes(), WithStore(store)); err != nil {
 				return fmt.Errorf("unable to push manifest: %w", err)
 			}
 		}
 	}
 
-	if err := client.PushManifestRaw(ctx, tgtRef, desc, rawManifest, WithStore(store)); err != nil {
+	if err := client.PushRawManifest(ctx, tgtRef, desc, rawManifest, WithStore(store)); err != nil {
 		return fmt.Errorf("unable to push manifest: %w", err)
 	}
 

--- a/ociclient/copy.go
+++ b/ociclient/copy.go
@@ -5,7 +5,9 @@
 package ociclient
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -15,17 +17,74 @@ import (
 // Copy copies a oci artifact from one location to a target ref.
 // The artifact is copied without any modification.
 // This function does directly stream the blobs from the upstream it does not use any cache.
-func Copy(ctx context.Context, client Client, from, to string) error {
-	artifact, err := client.GetOCIArtifact(ctx, from)
+func Copy(ctx context.Context, client Client, srcRef, tgtRef string) error {
+	desc, rawManifest, err := client.GetManifestRaw(ctx, srcRef)
 	if err != nil {
-		return fmt.Errorf("unable to get source oci artifact %q: %w", from, err)
+		return fmt.Errorf("unable to get manifest: %w", err)
 	}
 
 	store := GenericStore(func(ctx context.Context, desc ocispecv1.Descriptor, writer io.Writer) error {
-		return client.Fetch(ctx, from, desc, writer)
+		return client.Fetch(ctx, srcRef, desc, writer)
 	})
 
-	return client.PushOCIArtifact(ctx, to, artifact, WithStore(store))
+	if IsMultiArchImageMediaType(desc.MediaType) {
+		index := ocispecv1.Index{}
+		if err := json.Unmarshal(rawManifest, &index); err != nil {
+			return fmt.Errorf("unable to unmarshal image index: %w", err)
+		}
+
+		for _, manifestDesc := range index.Manifests {
+			buf := bytes.NewBuffer([]byte{})
+			if err := client.Fetch(ctx, srcRef, manifestDesc, buf); err != nil {
+				return fmt.Errorf("unable to get manifest: %w", err)
+			}
+			rawManifest := buf.Bytes()
+
+			manifest := ocispecv1.Manifest{}
+			if err := json.Unmarshal(rawManifest, &manifest); err != nil {
+				return fmt.Errorf("unable to unmarshal manifest: %w", err)
+			}
+
+			if err := client.PushBlob(ctx, tgtRef, manifest.Config, WithStore(store)); err != nil {
+				return fmt.Errorf("unable to push config: %w", err)
+			}
+
+			for _, layerDesc := range manifest.Layers {
+				if err := client.PushBlob(ctx, tgtRef, layerDesc, WithStore(store)); err != nil {
+					return fmt.Errorf("unable to push layer: %w", err)
+				}
+			}
+
+			if err := client.PushManifestRaw(ctx, tgtRef, manifestDesc, rawManifest); err != nil {
+				return fmt.Errorf("unable to push manifest: %w", err)
+			}
+		}
+
+		if err := client.PushManifestRaw(ctx, tgtRef, desc, rawManifest); err != nil {
+			return fmt.Errorf("unable to push index: %w", err)
+		}
+	} else {
+		manifest := ocispecv1.Manifest{}
+		if err := json.Unmarshal(rawManifest, &manifest); err != nil {
+			return fmt.Errorf("unable to unmarshal manifest: %w", err)
+		}
+
+		if err := client.PushBlob(ctx, tgtRef, manifest.Config, WithStore(store)); err != nil {
+			return fmt.Errorf("unable to push config: %w", err)
+		}
+
+		for _, layerDesc := range manifest.Layers {
+			if err := client.PushBlob(ctx, tgtRef, layerDesc, WithStore(store)); err != nil {
+				return fmt.Errorf("unable to push layer: %w", err)
+			}
+		}
+
+		if err := client.PushManifestRaw(ctx, tgtRef, desc, rawManifest); err != nil {
+			return fmt.Errorf("unable to push manifest: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // GenericStore is a helper struct to implement a custom oci blob store.

--- a/ociclient/types.go
+++ b/ociclient/types.go
@@ -19,26 +19,37 @@ import (
 
 type Client interface {
 	Resolver
-	// GetManifest returns the ocispec Manifest for a reference
-	GetManifest(ctx context.Context, ref string) (*ocispecv1.Manifest, error)
 
 	// Fetch fetches the blob for the given ocispec Descriptor.
 	Fetch(ctx context.Context, ref string, desc ocispecv1.Descriptor, writer io.Writer) error
 
-	// PushManifest uploads the given Manifest to the given reference.
-	PushManifest(ctx context.Context, ref string, manifest *ocispecv1.Manifest, opts ...PushOption) error
-
-	// GetOCIArtifact returns an OCIArtifact for a reference.
-	GetOCIArtifact(ctx context.Context, ref string) (*oci.Artifact, error)
-
-	// PushOCIArtifact uploads the given OCIArtifact to the given ref.
-	PushOCIArtifact(ctx context.Context, ref string, artifact *oci.Artifact, opts ...PushOption) error
-
 	// PushBlob uploads the blob for the given ocispec Descriptor to the given ref
 	PushBlob(ctx context.Context, ref string, desc ocispecv1.Descriptor, opts ...PushOption) error
 
-	GetManifestRaw(ctx context.Context, ref string) (ocispecv1.Descriptor, []byte, error)
-	PushManifestRaw(ctx context.Context, ref string, desc ocispecv1.Descriptor, rawManifest []byte, opts ...PushOption) error
+	// Deprecated: use GetRawManifest instead
+	// GetManifest returns the ocispec Manifest for a reference
+	GetManifest(ctx context.Context, ref string) (*ocispecv1.Manifest, error)
+
+	// Deprecated: use PushRawManifest instead
+	// PushManifest uploads the given Manifest to the given reference.
+	PushManifest(ctx context.Context, ref string, manifest *ocispecv1.Manifest, opts ...PushOption) error
+
+	// GetRawManifest returns the raw manifest for a reference.
+	// The returned manifest can either be single arch or multi arch (image index/manifest list)
+	GetRawManifest(ctx context.Context, ref string) (ocispecv1.Descriptor, []byte, error)
+
+	// PushRawManifest uploads the given raw manifest to the given reference.
+	// If the manifest is multi arch (image index/manifest list), only the multi arch manifest is pushed.
+	// The referenced single arch manifests must be pushed individiually before.
+	PushRawManifest(ctx context.Context, ref string, desc ocispecv1.Descriptor, rawManifest []byte, opts ...PushOption) error
+
+	// Deprecated: use GetRawManifest instead
+	// GetOCIArtifact returns an OCIArtifact for a reference.
+	GetOCIArtifact(ctx context.Context, ref string) (*oci.Artifact, error)
+
+	// Deprecated: use PushRawManifest instead
+	// PushOCIArtifact uploads the given OCIArtifact to the given ref.
+	PushOCIArtifact(ctx context.Context, ref string, artifact *oci.Artifact, opts ...PushOption) error
 }
 
 // ExtendedClient defines an oci client with extended functionality that may not work with all registries.

--- a/ociclient/types.go
+++ b/ociclient/types.go
@@ -36,15 +36,19 @@ type Client interface {
 	PushRawManifest(ctx context.Context, ref string, desc ocispecv1.Descriptor, rawManifest []byte, opts ...PushOption) error
 
 	// GetManifest returns the ocispec Manifest for a reference
+	// Deprecated: Please prefer GetRawManifest instead
 	GetManifest(ctx context.Context, ref string) (*ocispecv1.Manifest, error)
 
 	// PushManifest uploads the given Manifest to the given reference.
+	// Deprecated: Please prefer PushRawManifest instead
 	PushManifest(ctx context.Context, ref string, manifest *ocispecv1.Manifest, opts ...PushOption) error
 
 	// GetOCIArtifact returns an OCIArtifact for a reference.
+	// Deprecated: Please prefer GetRawManifest instead
 	GetOCIArtifact(ctx context.Context, ref string) (*oci.Artifact, error)
 
 	// PushOCIArtifact uploads the given OCIArtifact to the given ref.
+	// Deprecated: Please prefer PushRawManifest instead
 	PushOCIArtifact(ctx context.Context, ref string, artifact *oci.Artifact, opts ...PushOption) error
 }
 

--- a/ociclient/types.go
+++ b/ociclient/types.go
@@ -26,14 +26,6 @@ type Client interface {
 	// PushBlob uploads the blob for the given ocispec Descriptor to the given ref
 	PushBlob(ctx context.Context, ref string, desc ocispecv1.Descriptor, opts ...PushOption) error
 
-	// Deprecated: use GetRawManifest instead
-	// GetManifest returns the ocispec Manifest for a reference
-	GetManifest(ctx context.Context, ref string) (*ocispecv1.Manifest, error)
-
-	// Deprecated: use PushRawManifest instead
-	// PushManifest uploads the given Manifest to the given reference.
-	PushManifest(ctx context.Context, ref string, manifest *ocispecv1.Manifest, opts ...PushOption) error
-
 	// GetRawManifest returns the raw manifest for a reference.
 	// The returned manifest can either be single arch or multi arch (image index/manifest list)
 	GetRawManifest(ctx context.Context, ref string) (ocispecv1.Descriptor, []byte, error)
@@ -43,11 +35,15 @@ type Client interface {
 	// The referenced single arch manifests must be pushed individiually before.
 	PushRawManifest(ctx context.Context, ref string, desc ocispecv1.Descriptor, rawManifest []byte, opts ...PushOption) error
 
-	// Deprecated: use GetRawManifest instead
+	// GetManifest returns the ocispec Manifest for a reference
+	GetManifest(ctx context.Context, ref string) (*ocispecv1.Manifest, error)
+
+	// PushManifest uploads the given Manifest to the given reference.
+	PushManifest(ctx context.Context, ref string, manifest *ocispecv1.Manifest, opts ...PushOption) error
+
 	// GetOCIArtifact returns an OCIArtifact for a reference.
 	GetOCIArtifact(ctx context.Context, ref string) (*oci.Artifact, error)
 
-	// Deprecated: use PushRawManifest instead
 	// PushOCIArtifact uploads the given OCIArtifact to the given ref.
 	PushOCIArtifact(ctx context.Context, ref string, artifact *oci.Artifact, opts ...PushOption) error
 }

--- a/ociclient/types.go
+++ b/ociclient/types.go
@@ -36,6 +36,9 @@ type Client interface {
 
 	// PushBlob uploads the blob for the given ocispec Descriptor to the given ref
 	PushBlob(ctx context.Context, ref string, desc ocispecv1.Descriptor, opts ...PushOption) error
+
+	GetManifestRaw(ctx context.Context, ref string) (ocispecv1.Descriptor, []byte, error)
+	PushManifestRaw(ctx context.Context, ref string, desc ocispecv1.Descriptor, rawManifest []byte, opts ...PushOption) error
 }
 
 // ExtendedClient defines an oci client with extended functionality that may not work with all registries.

--- a/ociclient/utils.go
+++ b/ociclient/utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/containerd/containerd/images"
 	"github.com/opencontainers/go-digest"
 	ocispecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -72,4 +73,14 @@ func ParseImageRef(ref string) (repository, version string, err error) {
 func TagIsDigest(tag string) bool {
 	_, err := digest.Parse(tag)
 	return err == nil
+}
+
+func IsMultiArchImage(mediaType string) bool {
+	return mediaType == ocispecv1.MediaTypeImageIndex ||
+		mediaType == images.MediaTypeDockerSchema2ManifestList
+}
+
+func IsSingleArchImage(mediaType string) bool {
+	return mediaType == ocispecv1.MediaTypeImageManifest ||
+		mediaType == images.MediaTypeDockerSchema2Manifest
 }

--- a/pkg/testutils/oci.go
+++ b/pkg/testutils/oci.go
@@ -7,9 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
-	"strings"
 
 	. "github.com/onsi/gomega"
 	"github.com/opencontainers/go-digest"
@@ -17,112 +15,45 @@ import (
 	ocispecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/gardener/component-cli/ociclient"
-	"github.com/gardener/component-cli/ociclient/oci"
 )
 
-// UploadTestManifest uploads an oci image manifest to a registry
-func UploadTestManifest(ctx context.Context, client ociclient.Client, ref string) (*ocispecv1.Manifest, ocispecv1.Descriptor, error) {
-	configData := []byte("config-data")
-	layerData := []byte("layer-data")
-	manifest := &ocispecv1.Manifest{
-		Versioned: specs.Versioned{
-			SchemaVersion: 2,
-		},
-		Config: ocispecv1.Descriptor{
-			MediaType: "text/plain",
-			Digest:    digest.FromBytes(configData),
-			Size:      int64(len(configData)),
-		},
-		Layers: []ocispecv1.Descriptor{
-			{
-				MediaType: "text/plain",
-				Digest:    digest.FromBytes(layerData),
-				Size:      int64(len(layerData)),
-			},
-		},
-	}
-	store := ociclient.GenericStore(func(ctx context.Context, desc ocispecv1.Descriptor, writer io.Writer) error {
-		switch desc.Digest.String() {
-		case manifest.Config.Digest.String():
-			_, err := writer.Write(configData)
-			return err
-		default:
-			_, err := writer.Write(layerData)
-			return err
-		}
-	})
-
-	if err := client.PushManifest(ctx, ref, manifest, ociclient.WithStore(store)); err != nil {
-		return nil, ocispecv1.Descriptor{}, err
-	}
+// UploadTestImage uploads an oci image manifest to a registry
+func UploadTestImage(ctx context.Context, client ociclient.Client, ref, manifestMediaType string, configData []byte, layersData [][]byte) (ocispecv1.Descriptor, []byte) {
+	manifest, desc, blobMap := CreateImage(configData, layersData)
+	desc.MediaType = manifestMediaType
 
 	manifestBytes, err := json.Marshal(manifest)
-	if err != nil {
-		return nil, ocispecv1.Descriptor{}, err
-	}
+	Expect(err).ToNot(HaveOccurred())
 
-	desc := ocispecv1.Descriptor{
-		MediaType: ocispecv1.MediaTypeImageManifest,
-		Digest:    digest.FromBytes(manifestBytes),
-		Size:      int64(len(manifestBytes)),
-	}
+	store := ociclient.GenericStore(func(ctx context.Context, desc ocispecv1.Descriptor, writer io.Writer) error {
+		_, err := writer.Write(blobMap[desc.Digest])
+		return err
+	})
 
-	return manifest, desc, nil
+	Expect(client.PushRawManifest(ctx, ref, desc, manifestBytes, ociclient.WithStore(store))).To(Succeed())
+
+	return desc, manifestBytes
 }
 
 // UploadTestIndex uploads an oci image index to a registry
-func UploadTestIndex(ctx context.Context, client ociclient.Client, indexRef string) (*oci.Index, error) {
-	splitted := strings.Split(indexRef, ":")
-	indexRepo := strings.Join(splitted[0:len(splitted)-1], ":")
-	tag := splitted[len(splitted)-1]
+func UploadTestIndex(ctx context.Context, client ociclient.Client, ref, indexMediaType string, index ocispecv1.Index) (ocispecv1.Descriptor, []byte) {
+	indexBytes, err := json.Marshal(index)
+	Expect(err).ToNot(HaveOccurred())
 
-	manifest1Ref := fmt.Sprintf("%s-platform-1:%s", indexRepo, tag)
-	manifest2Ref := fmt.Sprintf("%s-platform-2:%s", indexRepo, tag)
-
-	manifest1, mdesc1, err := UploadTestManifest(ctx, client, manifest1Ref)
-	if err != nil {
-		return nil, err
-	}
-	mdesc1.Platform = &ocispecv1.Platform{
-		Architecture: "amd64",
-		OS:           "linux",
+	indexDesc := ocispecv1.Descriptor{
+		MediaType: indexMediaType,
+		Digest:    digest.FromBytes(indexBytes),
+		Size:      int64(len(indexBytes)),
 	}
 
-	manifest2, mdesc2, err := UploadTestManifest(ctx, client, manifest2Ref)
-	if err != nil {
-		return nil, err
-	}
-	mdesc2.Platform = &ocispecv1.Platform{
-		Architecture: "amd64",
-		OS:           "windows",
-	}
+	store := ociclient.GenericStore(func(ctx context.Context, desc ocispecv1.Descriptor, writer io.Writer) error {
+		_, err := writer.Write(indexBytes)
+		return err
+	})
 
-	index := oci.Index{
-		Manifests: []*oci.Manifest{
-			{
-				Descriptor: mdesc1,
-				Data:       manifest1,
-			},
-			{
-				Descriptor: mdesc2,
-				Data:       manifest2,
-			},
-		},
-		Annotations: map[string]string{
-			"test": "test",
-		},
-	}
+	Expect(client.PushRawManifest(ctx, ref, indexDesc, indexBytes, ociclient.WithStore(store))).To(Succeed())
 
-	ociArtifact, err := oci.NewIndexArtifact(&index)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := client.PushOCIArtifact(ctx, indexRef, ociArtifact); err != nil {
-		return nil, err
-	}
-
-	return &index, nil
+	return indexDesc, indexBytes
 }
 
 // CreateImage creates an oci image manifest.
@@ -168,20 +99,22 @@ func CreateImage(configData []byte, layersData [][]byte) (*ocispecv1.Manifest, o
 	return &manifest, manifestDesc, blobMap
 }
 
-func CompareRemoteManifest(client ociclient.Client, ref string, expectedManifest oci.Manifest, expectedCfgBytes []byte, expectedLayers [][]byte) {
-	buf := bytes.NewBuffer([]byte{})
-	Expect(client.Fetch(context.TODO(), ref, expectedManifest.Descriptor, buf)).To(Succeed())
-	manifestFromRemote := ocispecv1.Manifest{}
-	Expect(json.Unmarshal(buf.Bytes(), &manifestFromRemote)).To(Succeed())
-	Expect(manifestFromRemote).To(Equal(*expectedManifest.Data))
+func CompareRemoteManifest(ctx context.Context, client ociclient.Client, ref string, expectedManifestDesc ocispecv1.Descriptor, expectedManifestBytes []byte, expectedCfgBytes []byte, expectedLayers [][]byte) {
+	actualManifestDesc, actualManifestBytes, err := client.GetRawManifest(ctx, ref)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(actualManifestDesc).To(Equal(expectedManifestDesc))
+	Expect(actualManifestBytes).To(Equal(expectedManifestBytes))
 
-	buf = bytes.NewBuffer([]byte{})
-	Expect(client.Fetch(context.TODO(), ref, manifestFromRemote.Config, buf)).To(Succeed())
-	Expect(buf.Bytes()).To(Equal(expectedCfgBytes))
+	actualManifest := ocispecv1.Manifest{}
+	Expect(json.Unmarshal(actualManifestBytes, &actualManifest)).To(Succeed())
 
-	for i, layerDesc := range manifestFromRemote.Layers {
-		buf = bytes.NewBuffer([]byte{})
-		Expect(client.Fetch(context.TODO(), ref, layerDesc, buf)).To(Succeed())
-		Expect(buf.Bytes()).To(Equal(expectedLayers[i]))
+	actualConfigBuf := bytes.NewBuffer([]byte{})
+	Expect(client.Fetch(ctx, ref, actualManifest.Config, actualConfigBuf)).To(Succeed())
+	Expect(actualConfigBuf.Bytes()).To(Equal(expectedCfgBytes))
+
+	for i, layerDesc := range actualManifest.Layers {
+		actualLayerBuf := bytes.NewBuffer([]byte{})
+		Expect(client.Fetch(ctx, ref, layerDesc, actualLayerBuf)).To(Succeed())
+		Expect(actualLayerBuf.Bytes()).To(Equal(expectedLayers[i]))
 	}
 }

--- a/pkg/testutils/oci.go
+++ b/pkg/testutils/oci.go
@@ -26,6 +26,9 @@ func UploadTestManifest(ctx context.Context, client ociclient.Client, ref string
 	configData := []byte("config-data")
 	layerData := []byte("layer-data")
 	manifest := &ocispecv1.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
 		Config: ocispecv1.Descriptor{
 			MediaType: "text/plain",
 			Digest:    digest.FromBytes(configData),

--- a/pkg/transport/process/downloaders/oci_artifact_test.go
+++ b/pkg/transport/process/downloaders/oci_artifact_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/gardener/component-cli/pkg/testutils"
 	"github.com/gardener/component-cli/pkg/transport/process/downloaders"
 	"github.com/gardener/component-cli/pkg/transport/process/utils"
 )
@@ -43,15 +42,6 @@ var _ = Describe("ociArtifact", func() {
 			actualOciArtifact, err := utils.DeserializeOCIArtifact(resBlobReader, ociCache)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*actualOciArtifact.GetManifest()).To(Equal(expectedImageManifest))
-			testutils.CompareRemoteManifest(
-				ociClient,
-				imageRef,
-				expectedImageManifest,
-				[]byte("config-data"),
-				[][]byte{
-					[]byte("layer-data"),
-				},
-			)
 		})
 
 		It("should download and stream oci image index", func() {

--- a/pkg/transport/process/uploaders/oci_artifact_test.go
+++ b/pkg/transport/process/uploaders/oci_artifact_test.go
@@ -97,13 +97,6 @@ var _ = Describe("ociArtifact", func() {
 			actualOciArtifact, err := utils.DeserializeOCIArtifact(resBlobReader, cache.NewInMemoryCache())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actualOciArtifact).To(Equal(expectedOciArtifact))
-			testutils.CompareRemoteManifest(
-				ociClient,
-				expectedImageRef,
-				*expectedOciArtifact.GetManifest(),
-				configData,
-				layers,
-			)
 		})
 
 		It("should upload and stream oci image index", func() {
@@ -214,20 +207,6 @@ var _ = Describe("ociArtifact", func() {
 			actualOciArtifact, err := utils.DeserializeOCIArtifact(resBlobReader, cache.NewInMemoryCache())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(actualOciArtifact).To(Equal(expectedOciArtifact))
-			testutils.CompareRemoteManifest(
-				ociClient,
-				expectedImageRef,
-				*expectedOciArtifact.GetIndex().Manifests[0],
-				configData1,
-				layers1,
-			)
-			testutils.CompareRemoteManifest(
-				ociClient,
-				expectedImageRef,
-				*expectedOciArtifact.GetIndex().Manifests[1],
-				configData2,
-				layers2,
-			)
 		})
 
 		It("should return error for invalid access type", func() {

--- a/pkg/transport/process/uploaders/oci_artifact_test.go
+++ b/pkg/transport/process/uploaders/oci_artifact_test.go
@@ -53,7 +53,7 @@ var _ = Describe("ociArtifact", func() {
 			layers := [][]byte{
 				[]byte("layer-data"),
 			}
-			m, mdesc, _ := testutils.CreateImage(configData, layers)
+			m, mdesc, _ := testutils.CreateImage(ocispecv1.MediaTypeImageManifest, configData, layers)
 
 			expectedOciArtifact, err := oci.NewManifestArtifact(
 				&oci.Manifest{
@@ -132,13 +132,13 @@ var _ = Describe("ociArtifact", func() {
 				[]byte("layer-data-2"),
 			}
 
-			m1, m1Desc, _ := testutils.CreateImage(configData1, layers1)
+			m1, m1Desc, _ := testutils.CreateImage(ocispecv1.MediaTypeImageManifest, configData1, layers1)
 			m1Desc.Platform = &ocispecv1.Platform{
 				Architecture: "amd64",
 				OS:           "linux",
 			}
 
-			m2, m2Desc, _ := testutils.CreateImage(configData2, layers2)
+			m2, m2Desc, _ := testutils.CreateImage(ocispecv1.MediaTypeImageManifest, configData2, layers2)
 			m2Desc.Platform = &ocispecv1.Platform{
 				Architecture: "amd64",
 				OS:           "windows",

--- a/pkg/transport/process/uploaders/oci_artifact_test.go
+++ b/pkg/transport/process/uploaders/oci_artifact_test.go
@@ -53,7 +53,7 @@ var _ = Describe("ociArtifact", func() {
 			layers := [][]byte{
 				[]byte("layer-data"),
 			}
-			m, mdesc := testutils.CreateManifest(configData, layers, nil)
+			m, mdesc, _ := testutils.CreateImage(configData, layers)
 
 			expectedOciArtifact, err := oci.NewManifestArtifact(
 				&oci.Manifest{
@@ -139,13 +139,13 @@ var _ = Describe("ociArtifact", func() {
 				[]byte("layer-data-2"),
 			}
 
-			m1, m1Desc := testutils.CreateManifest(configData1, layers1, nil)
+			m1, m1Desc, _ := testutils.CreateImage(configData1, layers1)
 			m1Desc.Platform = &ocispecv1.Platform{
 				Architecture: "amd64",
 				OS:           "linux",
 			}
 
-			m2, m2Desc := testutils.CreateManifest(configData2, layers2, nil)
+			m2, m2Desc, _ := testutils.CreateImage(configData2, layers2)
 			m2Desc.Platform = &ocispecv1.Platform{
 				Architecture: "amd64",
 				OS:           "windows",

--- a/pkg/transport/process/utils/oci_artifact_serialization_test.go
+++ b/pkg/transport/process/utils/oci_artifact_serialization_test.go
@@ -30,7 +30,7 @@ var _ = Describe("oci artifact serialization", func() {
 			layers := [][]byte{
 				[]byte("layer-data"),
 			}
-			m, _, _ := testutils.CreateImage(configData, layers)
+			m, _, _ := testutils.CreateImage(ocispecv1.MediaTypeImageManifest, configData, layers)
 
 			expectedOciArtifact, err := oci.NewManifestArtifact(
 				&oci.Manifest{
@@ -76,13 +76,13 @@ var _ = Describe("oci artifact serialization", func() {
 				[]byte("layer-data-2"),
 			}
 
-			m1, m1Desc, _ := testutils.CreateImage(configData1, layers1)
+			m1, m1Desc, _ := testutils.CreateImage(ocispecv1.MediaTypeImageManifest, configData1, layers1)
 			m1Desc.Platform = &ocispecv1.Platform{
 				Architecture: "amd64",
 				OS:           "linux",
 			}
 
-			m2, m2Desc, _ := testutils.CreateImage(configData2, layers2)
+			m2, m2Desc, _ := testutils.CreateImage(ocispecv1.MediaTypeImageManifest, configData2, layers2)
 			m2Desc.Platform = &ocispecv1.Platform{
 				Architecture: "amd64",
 				OS:           "windows",

--- a/pkg/transport/process/utils/oci_artifact_serialization_test.go
+++ b/pkg/transport/process/utils/oci_artifact_serialization_test.go
@@ -30,7 +30,7 @@ var _ = Describe("oci artifact serialization", func() {
 			layers := [][]byte{
 				[]byte("layer-data"),
 			}
-			m, _ := testutils.CreateManifest(configData, layers, nil)
+			m, _, _ := testutils.CreateImage(configData, layers)
 
 			expectedOciArtifact, err := oci.NewManifestArtifact(
 				&oci.Manifest{
@@ -76,13 +76,13 @@ var _ = Describe("oci artifact serialization", func() {
 				[]byte("layer-data-2"),
 			}
 
-			m1, m1Desc := testutils.CreateManifest(configData1, layers1, nil)
+			m1, m1Desc, _ := testutils.CreateImage(configData1, layers1)
 			m1Desc.Platform = &ocispecv1.Platform{
 				Architecture: "amd64",
 				OS:           "linux",
 			}
 
-			m2, m2Desc := testutils.CreateManifest(configData2, layers2, nil)
+			m2, m2Desc, _ := testutils.CreateImage(configData2, layers2)
 			m2Desc.Platform = &ocispecv1.Platform{
 				Architecture: "amd64",
 				OS:           "windows",


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes handling of oci image indexes in oci client. these are now replicated 1:1 without modifications. therefore introduces new methods GetRawManifest and PushRawManifest on ocliclient.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- fix replication of oci image indexs (are now replicated 1:1)
```
