### PR TITLE
remove build date variable from install script

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -18,6 +18,5 @@ CGO_ENABLED=0 GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) GO111MODULE=on \
   -ldflags "-s -w \
             -X github.com/gardener/component-cli/pkg/version.gitVersion=$EFFECTIVE_VERSION \
             -X github.com/gardener/component-cli/pkg/version.gitTreeState=$([ -z git status --porcelain 2>/dev/null ] && echo clean || echo dirty) \
-            -X github.com/gardener/component-cli/pkg/version.gitCommit=$(git rev-parse --verify HEAD) \
-            -X github.com/gardener/component-cli/pkg/version.buildDate=$(date --rfc-3339=seconds | sed 's/ /T/')" \
+            -X github.com/gardener/component-cli/pkg/version.gitCommit=$(git rev-parse --verify HEAD)" \
   ${PROJECT_ROOT}/cmd/...


### PR DESCRIPTION
**What this PR does / why we need it**:
remove buildDate build time variable from install script.
this variable is effectively unused (not printed out in version command) and crashes the build for Mac OS (see #79)

makes #80 obsolete

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- remove buildDate build time variable from install script
```
