### PR TITLE
ca create better validation for missing paramters

### DIFF
--- a/pkg/commands/componentarchive/create.go
+++ b/pkg/commands/componentarchive/create.go
@@ -6,6 +6,7 @@ package componentarchive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -65,6 +66,14 @@ func (o *CreateOptions) Complete(args []string) error {
 		return fmt.Errorf("expected exactly one argument that contains the path to the component archive")
 	}
 	o.ComponentArchivePath = args[0]
+
+	if len(o.Name) == 0 {
+		return errors.New("a name has to be provided for a minimal component descriptor")
+	}
+
+	if len(o.Version) == 0 {
+		return errors.New("a version has to be provided for a minimal component descriptor")
+	}
 
 	return o.validate()
 }

--- a/pkg/componentarchive/archive.go
+++ b/pkg/componentarchive/archive.go
@@ -58,11 +58,14 @@ func (o *BuilderOptions) Validate() error {
 		return errors.New("a component archive path must be defined")
 	}
 
-	if len(o.Name) != 0 {
-		if len(o.Version) == 0 {
-			return errors.New("a version has to be provided for a minimal component descriptor")
-		}
+	if len(o.Name) == 0 {
+		return errors.New("a name has to be provided for a minimal component descriptor")
 	}
+
+	if len(o.Version) == 0 {
+		return errors.New("a version has to be provided for a minimal component descriptor")
+	}
+
 	if len(o.ComponentNameMapping) != 0 {
 		if o.ComponentNameMapping != string(cdv2.OCIRegistryURLPathMapping) &&
 			o.ComponentNameMapping != string(cdv2.OCIRegistryDigestMapping) {

--- a/pkg/componentarchive/archive.go
+++ b/pkg/componentarchive/archive.go
@@ -58,14 +58,11 @@ func (o *BuilderOptions) Validate() error {
 		return errors.New("a component archive path must be defined")
 	}
 
-	if len(o.Name) == 0 {
-		return errors.New("a name has to be provided for a minimal component descriptor")
+	if len(o.Name) != 0 {
+		if len(o.Version) == 0 {
+			return errors.New("a version has to be provided for a minimal component descriptor")
+		}
 	}
-
-	if len(o.Version) == 0 {
-		return errors.New("a version has to be provided for a minimal component descriptor")
-	}
-
 	if len(o.ComponentNameMapping) != 0 {
 		if o.ComponentNameMapping != string(cdv2.OCIRegistryURLPathMapping) &&
 			o.ComponentNameMapping != string(cdv2.OCIRegistryDigestMapping) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we now validate the created component descriptor in `ca create` against the json scheme, it is not possible to leave name and version empty. Therefore, the name and version parameter are now required.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
ca create now requires the --component-name and --component-version parameter
```
