### PR TITLE
remove CVE-2022-41720, update to golang:1.18.9

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -15,9 +15,9 @@ component-cli:
 
     steps:
       verify:
-        image: 'golang:1.16.7'
+        image: 'golang:1.18.9'
       build:
-        image: 'golang:1.16.7'
+        image: 'golang:1.18.9'
         execute: 'build'
         output_dir: 'out'
         timeout: '5m'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #### BUILDER ####
-FROM golang:1.18.4 AS builder
+FROM golang:1.18.9 AS builder
 
 WORKDIR /go/src/github.com/gardener/component-cli
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes CVE-2022-41717 & CVE-2022-41720

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
